### PR TITLE
Fixed prompt not showing properly in dumb frotz

### DIFF
--- a/src/dumb/dumb_input.c
+++ b/src/dumb/dumb_input.c
@@ -270,6 +270,7 @@ static bool dumb_read_line(char *s, char *prompt, bool show_cursor,
 	  if (!*current_page)
 	    break;
 	  printf("HELP: Type <return> for more, or q <return> to stop: ");
+	  fflush(stdout);
 	  dumb_getline(s);
 	  if (!strcmp(s, "q\n"))
 	    break;


### PR DESCRIPTION
Prompt was not showing up until after user submitted a line, because prompts
do not end with a newline, which would trigger fflush(). Adding a fflush() of
stdout fixes this.
