### PR TITLE
Fixing an issue with saving and restoring in some games.

### DIFF
--- a/src/common/quetzal.c
+++ b/src/common/quetzal.c
@@ -539,7 +539,7 @@ zword save_quetzal (FILE *svf, FILE *stf)
 	    || !write_word (svf, nstk))			return 0;
 
 	/* Write the variables and eval stack. */
-	for (j=0, ++p; j<nvars+nstk; ++j, --p)
+	for (j=0, --p; j<nvars+nstk; ++j, --p)
 	    if (!write_word (svf, *p))			return 0;
 
 	/* Calculate length written thus far. */


### PR DESCRIPTION
When saving and restoring in "Uninvited" if I do a look after restoring, I get an endless stream of:
[** Programming error: String (object number 4)  has no property actor_act to send message **]

Comparing the code in quetzal.c between frotz and Windows Frotz I noticed a change in the initialization of a for loop:
````
-       for (j=0, ++p; j<nvars+nstk; ++j, --p)
+       for (j=0, --p; j<nvars+nstk; ++j, --p)
````
I made the change, and now restoring works.