### PR TITLE
Fixing restart in games that have zcode in blorb files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+frotz
+dfrotz
+*.o
+*.a
+defines.h

--- a/src/common/fastmem.c
+++ b/src/common/fastmem.c
@@ -59,6 +59,8 @@ extern void script_close (void);
 
 extern FILE *os_path_open (const char *, const char *);
 extern FILE *os_load_story (void);
+extern int os_storyfile_seek (FILE * fp, long offset, int whence);
+extern int os_storyfile_tell (FILE * fp);
 
 extern zword save_quetzal (FILE *, FILE *);
 extern zword restore_quetzal (FILE *, FILE *);
@@ -327,9 +329,9 @@ void init_memory (void)
 
     } else {		/* some old games lack the file size entry */
 
-	fseek (story_fp, 0, SEEK_END);
-	story_size = ftell (story_fp);
-	fseek (story_fp, 64, SEEK_SET);
+	os_storyfile_seek (story_fp, 0, SEEK_END);
+	story_size = os_storyfile_tell (story_fp);
+	os_storyfile_seek (story_fp, 64, SEEK_SET);
 
     }
 
@@ -539,7 +541,7 @@ void z_restart (void)
 
     if (!first_restart) {
 
-	fseek (story_fp, 0, SEEK_SET);
+	os_storyfile_seek (story_fp, 0, SEEK_SET);
 
 	if (fread (zmp, 1, h_dynamic_size, story_fp) != h_dynamic_size)
 	    os_fatal ("Story file read error");
@@ -697,7 +699,7 @@ void z_restore (void)
 		    stack[i] |= fgetc (gfp);
 		}
 
-		fseek (story_fp, 0, SEEK_SET);
+		os_storyfile_seek (story_fp, 0, SEEK_SET);
 
 		for (addr = 0; addr < h_dynamic_size; addr++) {
 		    int skip = fgetc (gfp);
@@ -986,7 +988,7 @@ void z_save (void)
 		fputc ((int) lo (stack[i]), gfp);
 	    }
 
-	    fseek (story_fp, 0, SEEK_SET);
+	    os_storyfile_seek (story_fp, 0, SEEK_SET);
 
 	    for (addr = 0, skip = 0; addr < h_dynamic_size; addr++)
 		if (zmp[addr] != fgetc (story_fp) || skip == 255 || addr + 1 == h_dynamic_size) {
@@ -1112,7 +1114,8 @@ void z_verify (void)
 
     /* Sum all bytes in story file except header bytes */
 
-    fseek (story_fp, 64, SEEK_SET);
+    os_storyfile_seek (story_fp, 64, SEEK_SET);
+
 
     for (i = 64; i < story_size; i++)
 	checksum += fgetc (story_fp);

--- a/src/common/quetzal.c
+++ b/src/common/quetzal.c
@@ -48,6 +48,12 @@
 #define get_c fgetc
 #define put_c fputc
 
+/*
+ * externs
+ */
+
+extern int os_storyfile_seek(FILE * fp, long offset, int whence);
+
 typedef unsigned long zlong;
 
 /*
@@ -321,7 +327,7 @@ zword restore_quetzal (FILE *svf, FILE *stf)
 	    case ID_CMem:
 		if (!(progress & GOT_MEMORY))	/* Don't complain if two. */
 		{
-		    (void) fseek (stf, 0, SEEK_SET);
+		    (void) os_storyfile_seek (stf, 0, SEEK_SET);
 		    i=0;	/* Bytes written to data area. */
 		    for (; currlen > 0; --currlen)
 		    {
@@ -442,7 +448,7 @@ zword save_quetzal (FILE *svf, FILE *stf)
     /* Write `CMem' chunk. */
     if ((cmempos = ftell (svf)) < 0)			return 0;
     if (!write_chnk (svf, ID_CMem, 0))			return 0;
-    (void) fseek (stf, 0, SEEK_SET);
+    (void) os_storyfile_seek (stf, 0, SEEK_SET);
     /* j holds current run length. */
     for (i=0, j=0, cmemlen=0; i < h_dynamic_size; ++i)
     {

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -622,6 +622,53 @@ FILE *os_load_story(void)
     return fp;
 }
 
+/*
+ * Seek into a storyfile, either a standalone file or the
+ * ZCODE chunk of a blorb file
+ */
+int os_storyfile_seek(FILE * fp, long offset, int whence)
+{
+    /* Is this a Blorb file containing Zcode? */
+    if (u_setup.exec_in_blorb)
+    {
+	switch (whence)
+	{
+	    case SEEK_END:
+		return fseek(fp, blorb_res.data.startpos + blorb_res.length + offset, SEEK_SET);
+		break;
+	    case SEEK_CUR:
+		return fseek(fp, offset, SEEK_CUR);
+		break;
+	    case SEEK_SET:
+	    default:
+		return fseek(fp, blorb_res.data.startpos + offset, SEEK_SET);
+		break;
+	}
+    }
+    else
+    {
+	return fseek(fp, offset, whence);
+    }
+
+}
+
+/*
+ * Tell the position in a storyfile, either a standalone file
+ * or the ZCODE chunk of a blorb file
+ */ 
+int os_storyfile_tell(FILE * fp)
+{
+    /* Is this a Blorb file containing Zcode? */
+    if (u_setup.exec_in_blorb)
+    {
+	return ftell(fp) - blorb_res.data.startpos;
+    }
+    else
+    {
+	return ftell(fp);
+    }
+
+}
 
 /*
  * pathopen

--- a/src/dos/bcinit.c
+++ b/src/dos/bcinit.c
@@ -949,3 +949,51 @@ int dos_init_blorb(void)
     return 0;
 }
 
+/*
+ * Seek into a storyfile, either a standalone file or the 
+ * ZCODE chunk of a blorb file
+ */
+int os_storyfile_seek(FILE * fp, long offset, int whence)
+{
+    /* Is this a Blorb file containing Zcode? */
+    if (exec_in_blorb)
+    {
+       switch (whence)
+       {
+           case SEEK_END:
+               return fseek(fp, blorb_res.data.startpos + blorb_res.length + offset, SEEK_SET);
+               break;
+           case SEEK_CUR:
+               return fseek(fp, offset, SEEK_CUR);
+               break;
+           case SEEK_SET:
+           default:
+               return fseek(fp, blorb_res.data.startpos + offset, SEEK_SET);
+               break;
+       }
+    }
+    else
+    {
+       return fseek(fp, offset, whence);
+    }
+
+}
+
+/*
+ * Tell the position in a storyfile, either a standalone file 
+ * or the ZCODE chunk of a blorb file
+ */
+int os_storyfile_tell(FILE * fp)
+{
+    /* Is this a Blorb file containing Zcode? */
+    if (exec_in_blorb)
+    {
+       return ftell(fp) - blorb_res.data.startpos;
+    }
+    else
+    {
+       return ftell(fp);
+    }
+
+}
+

--- a/src/dumb/dumb_init.c
+++ b/src/dumb/dumb_init.c
@@ -175,6 +175,27 @@ FILE *os_load_story(void)
     return fopen(f_setup.story_file, "rb");
 }
 
+/*
+ * Seek into a storyfile, either a standalone file or the
+ * ZCODE chunk of a blorb file (dumb does not support blorb
+ * so this is just a wrapper for fseek)
+ */
+int os_storyfile_seek(FILE * fp, long offset, int whence)
+{
+    return fseek(fp, offset, whence);
+}
+
+/*
+ * Tell the position in a storyfile, either a standalone file
+ * or the ZCODE chunk of a blorb file (dumb does not support 
+ * blorb so this is just a wrapper for fseek)
+ */ 
+int os_storyfile_tell(FILE * fp)
+{
+    return ftell(fp);
+}
+
+
 void os_init_setup(void)
 {
 	f_setup.attribute_assignment = 0;


### PR DESCRIPTION
This change fixes restarting in games that are stored in blorb files.  It also fixes when you use the verify command on those files.  Before this change, using uninvited.zblorb as an example, 
````
>verify
The game file did not verify as intact, and may be corrupt.
>restart
Are you sure you want to restart? y

[** Programm lowomh  d te   fxx -tp  zzzk    jajs  d te  d te   error: b       mj      wlowomh  d te      lowomh  d te   fxx -tp  zzzk    jajs  d te  d te    z g
mmw 
````

The issue was that the code was using fseek(storyfile, 0, SEEK_SET) to go to the beginning of the file instead of going to the beginning of the zcode segment of the blorb file.  Similarly, to find the size of the zcode, in some cases the code would do a fseek(storyfile,0, SEEK_END) and then use ftell and use the result to determine the size of the zcode.

I replaced the use of fseek and ftell with an new os dependent os_storyfile_seek() and os_storyfile_tell() which, for zcode NOT in blorb files, just do fseek and ftell, but if the code IS in a blorb file, will seek relative to the beginning and end of the zcode segment and will report the corresponding position for os_storyfile_tell().