### PR TITLE
Add binding ctrl-w - deletes prev word

### DIFF
--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -284,6 +284,7 @@ typedef struct {
 #define ZC_HKEY_HELP 0x15
 #define ZC_HKEY_MAX 0x15
 #define ZC_ESCAPE 0x1b
+#define ZC_DEL_WORD 0x1c
 #define ZC_ASCII_MIN 0x20
 #define ZC_ASCII_MAX 0x7e
 #define ZC_BAD 0x7f

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -235,6 +235,7 @@ static int unix_read_char(int extkeys)
 	case MOD_CTRL ^ 'E': c = KEY_END; break;
 	case MOD_CTRL ^ 'D': c = KEY_DC; break;
 	case MOD_CTRL ^ 'K': c = KEY_EOL; break;
+	case MOD_CTRL ^ 'W': c = ZC_DEL_WORD; break;
 
 	default: break; /* Who knows? */
 	}
@@ -447,6 +448,23 @@ zchar os_read_line (int max, zchar *buf, int timeout, int width, int continued)
 		memmove(buf + scrpos, buf + scrpos + 1, len - scrpos);
 	    }
 	    break;
+	case ZC_DEL_WORD:
+		if (scrpos != 0) {
+			/* Search for start of preceding word */
+			int i = len;
+			while (i > 0 && buf[i] != ' ') {
+				mvaddch(y, x + i, ' ');
+				i--;
+			}
+
+			searchpos = -1;
+			int delta = scrpos - i;
+			len -= delta;
+			scrpos -= delta;
+			scrnmove(x + scrpos, x + scrpos + delta, delta);
+			memmove(buf + scrpos, buf + scrpos + delta, delta);
+		}
+		break;
 	case CHR_DEL:
 	case KEY_DC:		/* Delete following character */
 	    if (scrpos < len) {


### PR DESCRIPTION
Common key binding in readline, vim

As discussed in https://github.com/DavidGriffith/frotz/issues/11

Tested with Lost Pig.