### PR TITLE
Replace rindex() with strrchr()

### DIFF
--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -292,7 +292,7 @@ void os_process_arguments (int argc, char *argv[])
     f_setup.story_name = strdup(basename(argv[optind]));
 
     /* Now strip off the extension. */
-    p = rindex(f_setup.story_name, '.');
+    p = strrchr(f_setup.story_name, '.');
     if ((p != NULL) &&
         ((strcmp(p,EXT_BLORB2) == 0) ||
          (strcmp(p,EXT_BLORB3) == 0) ||


### PR DESCRIPTION
This fixes compilation on Android, and should be a general
improvement since rindex() is deprecated.

http://pubs.opengroup.org/onlinepubs/009695399/functions/rindex.html