### PR TITLE
Add configurable ar and ranlib paths in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Define path for ar
+AR = /usr/bin/ar
+
+# Define path for ranlib
+RANLIB = /usr/bin/ranlib
+
 # Define your C compiler.  I recommend gcc if you have it.
 # MacOS users should use "cc" even though it's really "gcc".
 #
@@ -240,40 +246,40 @@ common_lib:	$(COMMON_TARGET)
 $(COMMON_TARGET): $(COMMON_OBJECT)
 	@echo
 	@echo "Archiving common code..."
-	ar rc $(COMMON_TARGET) $(COMMON_OBJECT)
-	ranlib $(COMMON_TARGET)
+	$(AR) rc $(COMMON_TARGET) $(COMMON_OBJECT)
+	$(RANLIB) $(COMMON_TARGET)
 	@echo
 
 curses_lib:	config_curses $(CURSES_TARGET)
 $(CURSES_TARGET): $(CURSES_OBJECT)
 	@echo
 	@echo "Archiving curses interface code..."
-	ar rc $(CURSES_TARGET) $(CURSES_OBJECT)
-	ranlib $(CURSES_TARGET)
+	$(AR) rc $(CURSES_TARGET) $(CURSES_OBJECT)
+	$(RANLIB) $(CURSES_TARGET)
 	@echo
 
 dumb_lib:	$(DUMB_TARGET)
 $(DUMB_TARGET): $(DUMB_OBJECT)
 	@echo
 	@echo "Archiving dumb interface code..."
-	ar rc $(DUMB_TARGET) $(DUMB_OBJECT)
-	ranlib $(DUMB_TARGET)
+	$(AR) rc $(DUMB_TARGET) $(DUMB_OBJECT)
+	$(RANLIB) $(DUMB_TARGET)
 	@echo
 
 sdl_lib:	$(SDL_TARGET)
 $(SDL_TARGET): $(SDL_OBJECT)
 	@echo
 	@echo "Archiving SDL interface code..."
-	ar rc $(SDL_TARGET) $(SDL_OBJECT)
-	ranlib $(SDL_TARGET)
+	$(AR) rc $(SDL_TARGET) $(SDL_OBJECT)
+	$(RANLIB) $(SDL_TARGET)
 	@echo
 
 blorb_lib:	$(BLORB_TARGET)
 $(BLORB_TARGET): $(BLORB_OBJECT)
 	@echo
 	@echo "Archiving Blorb file handling code..."
-	ar rc $(BLORB_TARGET) $(BLORB_OBJECT)
-	ranlib $(BLORB_TARGET)
+	$(AR) rc $(BLORB_TARGET) $(BLORB_OBJECT)
+	$(RANLIB) $(BLORB_TARGET)
 	@echo
 
 


### PR DESCRIPTION
In OS X specifically, you can get into a bad state if you have Xcode *and* GCC installed. GCC versions of Ar and Ranlib are known to not work properly on OS X, and will cause your build to fail. The Apple versions of these utils are located in /usr/bin (where they are in most Unix-like systems). The easiest thing to do is explicitly define the absolute path to the binaries, but rather than hard-code this into a bunch of places we can make it configurable in the same way our compiler variable is. Using this change, I can compile successfully on OS X El Capitan with both Xcode and GCC installed.