### PR TITLE
frotz-issue-44: Added compiler support for Apple MacOS Sierra 10.12 plus MacPorts 2.4.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,8 @@ CURSES = -lncurses
 #INCL = -I/usr/pkg/include
 #INCL = -I/usr/freeware/include
 #INCL = -I/5usr/include
+## INCL path for Apple MacOS Sierra 10.12 plus MacPorts
+INCL = -I/opt/local/include
 
 # Just in case your operating system keeps its user-added libraries
 # somewhere unusual...
@@ -65,6 +67,8 @@ CURSES = -lncurses
 #LIB = -L/usr/pkg/lib
 #LIB = -L/usr/freeware/lib
 #LIB = -L/5usr/lib
+## LIB path for Apple MacOS Sierra 10.12 plus MacPorts
+LIB = -L/opt/local/lib
 
 # Uncomment this if you're compiling Unix Frotz on a machine that lacks 
 # the strrchr() libc library call.  If you don't know what this means,
@@ -187,7 +191,8 @@ all:	$(NAME) d$(NAME)
 .SUFFIXES: .c .o .h
 
 $(COMMON_OBJECT): %.o: %.c
-	$(CC) $(OPTS) -o $@ -c $<
+	#$(CC) $(OPTS) -o $@ -c $<
+	$(CC) $(OPTS) $(INCL) -o $@ -c $<
 
 $(BLORB_OBJECT): %.o: %.c
 	$(CC) $(CFLAGS) $(OPTS) -o $@ -c $<
@@ -196,7 +201,8 @@ $(DUMB_OBJECT): %.o: %.c
 	$(CC) $(CFLAGS) $(OPTS) -o $@ -c $<
 
 $(CURSES_OBJECT): %.o: %.c
-	$(CC) $(OPTS) -o $@ -c $<
+	#$(CC) $(OPTS) -o $@ -c $<
+	$(CC) $(OPTS) $(INCL) -o $@ -c $<
 
 
 ####################################

--- a/src/common/fastmem.c
+++ b/src/common/fastmem.c
@@ -682,7 +682,7 @@ void z_restore (void)
 {
     char new_name[MAX_FILE_NAME + 1];
     char default_name[MAX_FILE_NAME + 1];
-    FILE *gfp;
+    FILE *gfp = NULL;
 
     zword success = 0;
 

--- a/src/curses/ux_blorb.h
+++ b/src/curses/ux_blorb.h
@@ -21,7 +21,8 @@ typedef struct sampledata_struct {
  */
 typedef struct {
     bb_result_t bbres;
-    ulong type;
+    // ulong type;
+    uint32_t type;
     FILE *fp;
 } myresource;
 

--- a/src/curses/ux_blorb.h
+++ b/src/curses/ux_blorb.h
@@ -22,7 +22,7 @@ typedef struct sampledata_struct {
 typedef struct {
     bb_result_t bbres;
     // ulong type;
-    uint32_t type;
+    unsigned long type;
     FILE *fp;
 } myresource;
 

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -993,7 +993,7 @@ does nothing.
 static void sigint_handler(int dummy)
 {
     signal(SIGINT, sigint_handler);
-    dummy = dummy;
+    // dummy = dummy;
 
     os_stop_sample(0);
     scrollok(stdscr, TRUE); scroll(stdscr);

--- a/src/curses/ux_resource.c
+++ b/src/curses/ux_resource.c
@@ -24,7 +24,7 @@ int ux_getresource( int num, int ispic, int method, myresource * res)
 {
     int st;
     // ulong usage;
-    uint32_t usage;
+    unsigned long usage;
 
     res->bbres.data.ptr = NULL;
     res->fp = NULL;

--- a/src/curses/ux_resource.c
+++ b/src/curses/ux_resource.c
@@ -23,7 +23,8 @@ bb_map_t *blorb_map;
 int ux_getresource( int num, int ispic, int method, myresource * res)
 {
     int st;
-    ulong usage;
+    // ulong usage;
+    uint32_t usage;
 
     res->bbres.data.ptr = NULL;
     res->fp = NULL;


### PR DESCRIPTION
Resolve frotz issue 44.

Added compiler support for Apple MacOS Sierra 10.12 plus MacPorts 2.4.1.