### PR TITLE
Provide dfrotz `f_setup.command_name` with an initial buffer

### DIFF
--- a/src/dumb/dumb_init.c
+++ b/src/dumb/dumb_init.c
@@ -165,6 +165,10 @@ void os_process_arguments(int argc, char *argv[])
     f_setup.script_name = malloc(strlen(f_setup.story_name) * sizeof(char) + 5);
     strncpy(f_setup.script_name, f_setup.story_name, strlen(f_setup.story_name));
     strncat(f_setup.script_name, EXT_SCRIPT, strlen(EXT_SCRIPT));
+
+    f_setup.command_name = malloc((strlen(f_setup.story_name) + strlen(EXT_COMMAND)) * sizeof(char) + 1);
+    strncpy(f_setup.command_name, f_setup.story_name, strlen(f_setup.story_name) + 1);
+    strncat(f_setup.command_name, EXT_COMMAND, strlen(EXT_COMMAND));
 }
 
 void os_init_screen(void)


### PR DESCRIPTION
Without this initialization `f_setup.command_name` is NULL, but e.g. `replay_open()` assumes that it points to a valid buffer, and produces a segfault if it does not.  In particular, this causes `dfrotz` to segfault when attempting to replay a command playback file.