### PR TITLE
Add option in Makefile to compile for large/fullscreen terminal windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ CURSES = -lncurses
 #
 #INSTALL_NO_D_FLAG = true
 
+# Uncomment this if you plan on using Frotz in a terminal window more
+# than 255 characters wide.
+#
+#WIDE_SCREEN = -DWIDE_SCREEN
+
 # Just in case your operating system keeps its user-added header files
 # somewhere unusual...
 #
@@ -175,11 +180,11 @@ SOUND_LIB = -lao -ldl -lpthread -lm -lsndfile -lvorbisfile -lmodplug -lsamplerat
 $(NAME): $(COMMON_DIR)/git_hash.h $(COMMON_DIR)/defines.h $(CURSES_DIR)/defines.h $(COMMON_TARGET) $(CURSES_TARGET) $(BLORB_TARGET)
 	@echo Linking $(NAME)...
 ifeq ($(SOUND), ao)
-	$(CC) -o $(BINNAME)$(EXTENSION) $(TARGETS) $(LIB) $(CURSES) $(SOUND_LIB)
+	$(CC) -o $(BINNAME)$(EXTENSION) $(TARGETS) $(LIB) $(CURSES) $(WIDE_SCREEN) $(SOUND_LIB)
 else ifeq ($(SOUND), none)
-	$(CC) -o $(BINNAME)$(EXTENSION) $(TARGETS) $(LIB) $(CURSES) -DNO_SOUND
+	$(CC) -o $(BINNAME)$(EXTENSION) $(TARGETS) $(LIB) $(CURSES) $(WIDE_SCREEN) -DNO_SOUND
 else ifndef SOUND
-	$(CC) -o $(BINNAME)$(EXTENSION) $(TARGETS) $(LIB) $(CURSES) -DNO_SOUND
+	$(CC) -o $(BINNAME)$(EXTENSION) $(TARGETS) $(LIB) $(CURSES) $(WIDE_SCREEN) -DNO_SOUND
 else
 	@echo "Invalid sound choice $(SOUND)."
 endif

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -465,8 +465,16 @@ void os_init_screen (void)
     h_screen_width = h_screen_cols;
     h_screen_height = h_screen_rows;
 
+#ifdef WIDE_SCREEN
+    if (h_screen_width < 1)
+	os_fatal("Invalid screen width. Must be between 1 and 255.");
+
+    if (h_screen_width > 255)
+	h_screen_width = 255;
+#else
     if (h_screen_width > 255 || h_screen_width < 1)
 	os_fatal("Invalid screen width. Must be between 1 and 255.");
+#endif
 
     h_font_width = 1;
     h_font_height = 1;

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -45,19 +45,6 @@
 #include "ux_frotz.h"
 #include "ux_blorb.h"
 
-f_setup_t f_setup;
-u_setup_t u_setup;
-
-static int getconfig(char *);
-static int geterrmode(char *);
-static int getcolor(char *);
-static int getbool(char *);
-
-/* static void sigwinch_handler(int); */
-static void sigint_handler(int);
-/* static void redraw(void); */
-
-
 #define INFORMATION "\
 An interpreter for all Infocom and other Z-Machine games.\n\
 \n\
@@ -80,6 +67,13 @@ Syntax: frotz [options] story-file\n\
 char stripped_story_name[FILENAME_MAX+1];
 char semi_stripped_story_name[FILENAME_MAX+1];
 */
+
+f_setup_t f_setup;
+u_setup_t u_setup;
+
+/* static void sigwinch_handler(int); */
+static void sigint_handler(int);
+/* static void redraw(void); */
 
 static int zgetopt (int, char **, const char *);
 static int zoptind = 1;


### PR DESCRIPTION
I personally like to have my terminal window set to fullscreen; unfortunately, my monitor is wide enough that the fullscreen terminal is more than 255 characters wide (which ncurses apparently doesn't like). This meant that when I first compiled frotz and ran a game, the entire thing was squashed into a column about 10 characters wide on the left-hand side of the screen. These commits add an option to compile frotz such that if it is invoked with a width greater than 255, it will simply set the width to 255, rather than giving ncurses a bad value; this was the workaround I used, and I thought other people might benefit from it as well.