### PR TITLE
Allow color 'yellow' for option -f and -b

### DIFF
--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -920,6 +920,8 @@ static int getcolor(char *value)
 		return CYAN_COLOUR;
 	if (strcmp(value, "white") == 0)
 		return WHITE_COLOUR;
+	if (strcmp(value, "yellow") == 0)
+		return YELLOW_COLOUR;
 
 	if (strcmp(value, "purple") == 0)
 		return MAGENTA_COLOUR;


### PR DESCRIPTION
This color was missing in `getcolor()`, but is supported by the ncurses backend, so add it.