### PR TITLE
Clear line

### DIFF
--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -321,6 +321,7 @@ typedef struct {
 #define ZC_DEL_WORD 0x1c
 #define ZC_WORD_RIGHT 0x1d
 #define ZC_WORD_LEFT 0x1e
+#define ZC_DEL_TO_BOL 0x1f
 #define ZC_ASCII_MIN 0x20
 #define ZC_ASCII_MAX 0x7e
 #define ZC_BAD 0x7f

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -241,6 +241,8 @@ static int unix_read_char(int extkeys)
 
 	/* these are the emacs-editing characters */
 	case MOD_CTRL ^ 'B': return ZC_ARROW_LEFT;
+	/* use ^C to clear line anywhere it doesn't send SIGINT */
+	case MOD_CTRL ^ 'C': return ZC_ESCAPE;
 	case MOD_CTRL ^ 'F': return ZC_ARROW_RIGHT;
 	case MOD_CTRL ^ 'P': return ZC_ARROW_UP;
 	case MOD_CTRL ^ 'N': return ZC_ARROW_DOWN;


### PR DESCRIPTION
Anywhere ^C isn't being used to send SIGINT, it instead clears the current line, as requested.
https://github.com/DavidGriffith/frotz/issues/37

Patch 2 adds another standard UNIX command-line key, ^U, which traditionally clears from the character before point to beginning of line. Previously, frotz cleared the whole line with ^U.

At some point, I'd like to break some of these code blocks out into proper functions (e.g., have a delete_backwards(oldpos, newpos) function, which would cover a lot of spots in that big ol' case statement...

Also, I didn't mess with the indentation in the file, which is a mix of spaces and tabs.

Also also, in src/common/frotz.h, I kept with the convention of defining a hex value for the new bit. Out of curiosity, though, is there a reason that we care about most of those arbitrary values instead of just using an enum?