### PR TITLE
Makefile: make -llibs LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ BUFFSIZE ?= 4096
 DEFAULT_CONVERTER ?= SRC_SINC_MEDIUM_QUALITY
 
 ifeq ($(SOUND), ao)
-	CFLAGS += -lao -ldl -lpthread -lm -lsndfile -lvorbisfile -lmodplug -lsamplerate
+	LDFLAGS += -lao -ldl -lpthread -lm -lsndfile -lvorbisfile -lmodplug -lsamplerate
 else ifeq ($(SOUND), none)
 	CFLAGS += -DNO_SOUND
 else ifndef SOUND


### PR DESCRIPTION
Rationale: clang (correctly) warns about unused linker flags if these are set as CFLAGS. My mistake in the original Makefile re-do.