### PR TITLE
src/common/quetzal.c: make fallthrough explicit

### DIFF
--- a/src/common/quetzal.c
+++ b/src/common/quetzal.c
@@ -377,6 +377,7 @@ zword restore_quetzal (FILE *svf, FILE *stf)
 		    break;
 	    }
 		/* Fall right thru (to default) if already GOT_MEMORY */
+		__attribute__((fallthrough));
 	    /* `UMem' uncompressed memory chunk; load it. */
 	    case ID_UMem:
 		if (!(progress & GOT_MEMORY))	/* Don't complain if two. */
@@ -395,6 +396,7 @@ zword restore_quetzal (FILE *svf, FILE *stf)
 		    /* Fall into default action (skip chunk) on errors. */
 		}
 		/* Fall thru (to default) if already GOT_MEMORY */
+		__attribute__((fallthrough));
 	    /* Unrecognised chunk type; skip it. */
 	    default:
 		(void) fseek (svf, currlen, SEEK_CUR);	/* Skip chunk. */


### PR DESCRIPTION
This silences compiler warnings about this deliberate decision, so in
future it will be easier to spot compiler warnings about mistakes;
also, it should now be possible to compile with -Wall -Wextra -Werror.