### PR TITLE
Terminal resizing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dfrotz
 src/*/defines.h
 src/common/git_hash.h
 *.z?
+src/test/*mem
+src/test/*rec

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dfrotz
 *.BAK
 *.SWP
 *.DSK
+*.EXE
+*.LIB
 *.a
 src/*/defines.h
 src/common/git_hash.h
+*.z?

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ BUFFSIZE ?= 4096
 DEFAULT_CONVERTER ?= SRC_SINC_MEDIUM_QUALITY
 
 ifeq ($(SOUND), ao)
-	CFLAGS += -lao -ldl -lpthread -lm -lsndfile -lvorbisfile -lmodplug -lsamplerate
+	LDFLAGS += -lao -ldl -lpthread -lm -lsndfile -lvorbisfile -lmodplug -lsamplerate
 else ifeq ($(SOUND), none)
 	CFLAGS += -DNO_SOUND
 else ifndef SOUND
@@ -153,10 +153,10 @@ BLORB_OBJECT =  $(BLORB_DIR)/blorblib.o
 # Main programs
 
 frotz: $(SRCDIR)/frotz_common.a $(SRCDIR)/frotz_curses.a $(SRCDIR)/blorblib.a
-	$(CC) $(CFLAGS) $(CURSES) $(LDFLAGS) $^ -o $@$(EXTENSION)
+	$(CC) $(CFLAGS) $^ -o $@$(EXTENSION) $(CURSES) $(LDFLAGS)
 
 dfrotz:  $(SRCDIR)/frotz_common.a $(SRCDIR)/frotz_dumb.a $(SRCDIR)/blorblib.a
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@$(EXTENSION)
+	$(CC) $(CFLAGS) $^ -o $@$(EXTENSION) $(LDFLAGS)
 
 all: frotz dfrotz
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ COLOR = yes
 CURSES = -lncurses
 #CURSES = -lcurses
 
+# Uncomment this if your machine's version of install doesn't recognize
+# the -D option.
+#
+#INSTALL_NO_D_FLAG = true
+
 # Just in case your operating system keeps its user-added header files
 # somewhere unusual...
 #
@@ -57,6 +62,8 @@ CURSES = -lncurses
 #INCL = -I/usr/pkg/include
 #INCL = -I/usr/freeware/include
 #INCL = -I/5usr/include
+## INCL path for Apple MacOS Sierra 10.12 plus MacPorts
+INCL = -I/opt/local/include
 
 # Just in case your operating system keeps its user-added libraries
 # somewhere unusual...
@@ -65,6 +72,8 @@ CURSES = -lncurses
 #LIB = -L/usr/pkg/lib
 #LIB = -L/usr/freeware/lib
 #LIB = -L/5usr/lib
+## LIB path for Apple MacOS Sierra 10.12 plus MacPorts
+LIB = -L/opt/local/lib
 
 # Uncomment this if you're compiling Unix Frotz on a machine that lacks 
 # the strrchr() libc library call.  If you don't know what this means,
@@ -187,7 +196,8 @@ all:	$(NAME) d$(NAME)
 .SUFFIXES: .c .o .h
 
 $(COMMON_OBJECT): %.o: %.c
-	$(CC) $(OPTS) -o $@ -c $<
+	#$(CC) $(OPTS) -o $@ -c $<
+	$(CC) $(OPTS) $(INCL) -o $@ -c $<
 
 $(BLORB_OBJECT): %.o: %.c
 	$(CC) $(CFLAGS) $(OPTS) -o $@ -c $<
@@ -196,7 +206,8 @@ $(DUMB_OBJECT): %.o: %.c
 	$(CC) $(CFLAGS) $(OPTS) -o $@ -c $<
 
 $(CURSES_OBJECT): %.o: %.c
-	$(CC) $(OPTS) -o $@ -c $<
+	#$(CC) $(OPTS) -o $@ -c $<
+	$(CC) $(OPTS) $(INCL) -o $@ -c $<
 
 
 ####################################
@@ -286,16 +297,26 @@ $(BLORB_TARGET): $(BLORB_OBJECT)
 	@echo
 
 install: $(NAME)
+ifeq ($(INSTALL_NO_D_FLAG), true)
+	@install -d $(DESTDIR)$(PREFIX)/bin -m 755 $(BINNAME)$(EXTENSION) "$(DESTDIR)$(PREFIX)/bin/$(BINNAME)$(EXTENSION)"
+	@install -d $(DESTDIR)$(MAN_PREFIX)/man/man6 -m 644 doc/$(NAME).6 "$(DESTDIR)$(MAN_PREFIX)/man/man6/$(NAME).6"
+else
 	@install -D -m 755 $(BINNAME)$(EXTENSION) "$(DESTDIR)$(PREFIX)/bin/$(BINNAME)$(EXTENSION)"
 	@install -D -m 644 doc/$(NAME).6 "$(DESTDIR)$(MAN_PREFIX)/man/man6/$(NAME).6"
+endif
 
 uninstall:
 	@rm -f "$(DESTDIR)$(PREFIX)/bin/$(NAME)"
 	@rm -f "$(DESTDIR)$(MAN_PREFIX)/man/man6/$(NAME).6"
 
 install_dumb: d$(NAME)
+ifeq ($(INSTALL_NO_D_FLAG), true)
+	@install -d $(DESTDIR)$(PREFIX)/bin -m 755 d$(BINNAME)$(EXTENSION) "$(DESTDIR)$(PREFIX)/bin/d$(BINNAME)$(EXTENSION)"
+	@install -d $(DESTDIR)$(MAN_PREFIX)/man/man6 -m 644 doc/d$(NAME).6 "$(DESTDIR)$(MAN_PREFIX)/man/man6/d$(NAME).6"
+else
 	@install -D -m 755 d$(BINNAME)$(EXTENSION) "$(DESTDIR)$(PREFIX)/bin/d$(BINNAME)$(EXTENSION)"
 	@install -D -m 644 doc/d$(NAME).6 "$(DESTDIR)$(MAN_PREFIX)/man/man6/d$(NAME).6"
+endif
 
 uninstall_dumb:
 	@rm -f "$(DESTDIR)$(PREFIX)/bin/d$(NAME)"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ ifneq ($(and $(wildcard $(GIT_DIR)),$(shell which git)),)
 	GIT_HASH = $(shell git rev-parse HEAD)
 	GIT_HASH_SHORT = $(shell git rev-parse --short HEAD)
 	GIT_TAG = $(shell git describe --abbrev=0 --tags)
-	
 else
 	GIT_BRANCH = none
 	GIT_HASH = none
@@ -150,6 +149,10 @@ DUMB_OBJECT = $(DUMB_DIR)/dumb_init.o \
 BLORB_DIR = $(SRCDIR)/blorb
 BLORB_OBJECT =  $(BLORB_DIR)/blorblib.o
 
+OBJECTS = $(COMMON_OBJECT) $(CURSES_OBJECT) $(DUMB_OBJECT) $(BLORB_OBJECT)
+
+all: frotz dfrotz
+
 # Main programs
 
 frotz: $(SRCDIR)/frotz_common.a $(SRCDIR)/frotz_curses.a $(SRCDIR)/blorblib.a
@@ -157,8 +160,6 @@ frotz: $(SRCDIR)/frotz_common.a $(SRCDIR)/frotz_curses.a $(SRCDIR)/blorblib.a
 
 dfrotz:  $(SRCDIR)/frotz_common.a $(SRCDIR)/frotz_dumb.a $(SRCDIR)/blorblib.a
 	$(CC) $(CFLAGS) $^ -o $@$(EXTENSION) $(LDFLAGS)
-
-all: frotz dfrotz
 
 # Libs
 
@@ -171,7 +172,7 @@ all: frotz dfrotz
 
 common_lib: $(SRCDIR)/frotz_common.a
 $(SRCDIR)/frotz_common.a: $(COMMON_DIR)/git_hash.h $(COMMON_DIR)/defines.h $(COMMON_OBJECT)
- 
+
 curses_lib: $(SRCDIR)/frotz_curses.a
 $(SRCDIR)/frotz_curses.a: $(CURSES_DIR)/defines.h $(CURSES_OBJECT)
 
@@ -242,12 +243,11 @@ uninstall_dfrotz uninstall_dumb:
 dist: frotz-$(GIT_TAG).tar.gz
 frotz-$(GIT_TAG).tar.gz:
 	git archive --format=tar.gz -o "frotz-$(GIT_TAG).tar.gz" "$(GIT_TAG)"
-	
+
 clean:
 	rm -f $(SRCDIR)/*.h $(SRCDIR)/*.a $(COMMON_DIR)/defines.h \
 		$(COMMON_DIR)/git_hash.h $(CURSES_DIR)/defines.h \
-		frotz*.tar.gz
-	find . -iname *.o -delete
+		$(OBJECTS) frotz*.tar.gz
 
 help:
 	@echo "Targets:"

--- a/README
+++ b/README
@@ -7,7 +7,7 @@ Reference code and Unix port currently maintained by David Griffith.
 
 - Compiles and runs on most common flavors of Unix, both open source and not.
 - Plays all Z-code games including V6.
-- Old-style sound support through OSS driver.
+- Sound support through libao.
 - Config files.
 - Configurable error checking.
 - Distributed under the GNU Public License.

--- a/README
+++ b/README
@@ -25,12 +25,6 @@ For information on known bugs in Frotz, see the file "BUGS".
 For bug reports, check the Unix Frotz website to see if there's a new
 release.  If not, send your bug report to me at dave@661.org.
 
-For information on porting Frotz to new platforms, see the file "PORTING".
-
-For those who are involved in creating and distributing binary packages
-containing Frotz and including Frotz in BSD-style ports/pkgsrc trees,
-see the file "PACKAGING".
-
 The latest information on and source code of Unix Frotz is available at 
 https://github.com/DavidGriffith/frotz
 

--- a/doc/dfrotz.6
+++ b/doc/dfrotz.6
@@ -56,6 +56,10 @@ intended to get around such bugs, but be warned that Strange Things may
 happen if fatal errors are not caught.
 
 .TP
+.B \-L <filename>
+When the game starts, load this saved game file.
+
+.TP
 .B \-m
 Turn off MORE prompts.  This can be desirable when using a printing 
 terminal.
@@ -88,8 +92,20 @@ Z-code.
 Set runtime options.  This option may be used repeatedly.
 
 .TP
-.B \-R <filename>
-When the game starts, load this saved game file.
+.B \-R <path>
+Restricted read/write.  Reading and writing files will be restricted
+only to the provided path. Ordinarily Frotz will write or read its
+saves, transcripts, and move recordings in whatever path or directory
+the user provides when the
+.B SAVE,
+.B SCRIPT,
+or
+.B RECORDING
+commands are given.  This can be undesirable if Frotz is run in a
+restricted environment, by a front end, or by a chatbot.  This option will
+cause Frotz to write or read only to the provided path and nowhere else.
+Then the controlling process can then watch that directory for changes
+and need not worry about someone scribbling or snooping who-knows-where.
 
 .TP
 .B \-s N

--- a/doc/frotz.6
+++ b/doc/frotz.6
@@ -97,6 +97,10 @@ happen if fatal errors are not caught.
 Sets the left margin, for those who might have specific formatting needs.
 
 .TP
+.B \-L <filename>
+When the game starts, load this saved game file.
+
+.TP
 .B \-o
 Watch object movement.  This option enables debugging messages from the
 interpreter which describe the moving of objects in the object tree.
@@ -130,8 +134,20 @@ noises.
 Sets the right margin.
 
 .TP
-.B \-R <filename>
-When the game starts, load this saved game file.
+.B \-R <path>
+Restricted read/write.  Reading and writing files will be restricted
+only to the provided path. Ordinarily Frotz will write or read its
+saves, transcripts, and move recordings in whatever path or directory
+the user provides when the
+.B SAVE,
+.B SCRIPT,
+or
+.B RECORDING
+commands are given.  This can be undesirable if Frotz is run in a
+restricted environment, by a front end, or by a chatbot.  This option will
+cause Frotz to write or read only to the provided path and nowhere else.
+Then the controlling process can then watch that directory for changes
+and need not worry about someone scribbling or snooping who-knows-where.
 
 .TP
 .B \-s N

--- a/src/common/fastmem.c
+++ b/src/common/fastmem.c
@@ -51,7 +51,6 @@
 
 extern void seed_random (int);
 extern void restart_screen (void);
-extern void resize_screen (void);
 extern void refresh_text_style (void);
 extern void call (zword, int, zword *, int);
 extern void split_window (zword);

--- a/src/common/fastmem.c
+++ b/src/common/fastmem.c
@@ -683,7 +683,7 @@ void z_restore (void)
 {
     char new_name[MAX_FILE_NAME + 1];
     char default_name[MAX_FILE_NAME + 1];
-    FILE *gfp;
+    FILE *gfp = NULL;
 
     zword success = 0;
 
@@ -868,8 +868,6 @@ static void mem_undiff (zbyte *diff, long diff_length, zbyte *dest)
  */
 int restore_undo (void)
 {
-    long pc = curr_undo->pc;
-
     if (f_setup.undo_slots == 0)	/* undo feature unavailable */
 
 	return -1;
@@ -881,7 +879,7 @@ int restore_undo (void)
     /* undo possible */
 
     memcpy (zmp, prev_zmp, h_dynamic_size);
-    SET_PC (pc);
+    SET_PC (curr_undo->pc);
     sp = stack + STACK_SIZE - curr_undo->stack_size;
     fp = stack + curr_undo->frame_offset;
     frame_count = curr_undo->frame_count;

--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -321,6 +321,7 @@ typedef struct {
 #define ZC_DEL_WORD 0x1c
 #define ZC_WORD_RIGHT 0x1d
 #define ZC_WORD_LEFT 0x1e
+#define ZC_DEL_TO_BOL 0x1f
 #define ZC_ASCII_MIN 0x20
 #define ZC_ASCII_MAX 0x7e
 #define ZC_BAD 0x7f
@@ -788,6 +789,7 @@ void 	os_stop_sample ();
 int  	os_string_width (const zchar *);
 void	os_init_setup (void);
 void 	os_warn (const char *, ...);
+void	os_quit (void);
 
 /* Front ends call this if the terminal size changes. */
 void    resize_screen(void);

--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -789,6 +789,9 @@ int  	os_string_width (const zchar *);
 void	os_init_setup (void);
 void 	os_warn (const char *, ...);
 
+/* Front ends call this if the terminal size changes. */
+void    resize_screen(void);
+
 /* This is callable only from resize_screen. */
 bool    os_repaint_window (int win, int ypos_old, int ypos_new, int xpos,
                            int ysize, int xsize);

--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -27,6 +27,25 @@ typedef int bool;
 #define FALSE 0
 #endif
 
+#ifndef PATH_MAX
+#  ifdef MAXPATHLEN                /* defined in <sys/param.h> some systems */
+#    define PATH_MAX      MAXPATHLEN
+#  else
+#    if FILENAME_MAX > 255         /* used like PATH_MAX on some systems */
+#      define PATH_MAX    FILENAME_MAX
+#    else
+#      define PATH_MAX    (FILNAMSIZ - 1)
+#    endif
+#  endif /* ?MAXPATHLEN */
+#endif /* !PATH_MAX */
+
+
+#if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(_WIN64) || defined (__CYGWIN__)
+#define PATH_SEPARATOR '\\'
+#else
+#define PATH_SEPARATOR '/'
+#endif
+
 /* typedef unsigned short zbyte; */
 typedef unsigned char zbyte;
 typedef unsigned short zword;

--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -788,3 +788,7 @@ void 	os_stop_sample ();
 int  	os_string_width (const zchar *);
 void	os_init_setup (void);
 void 	os_warn (const char *, ...);
+
+/* This is callable only from resize_screen. */
+bool    os_repaint_window (int win, int ypos_old, int ypos_new, int xpos,
+                           int ysize, int xsize);

--- a/src/common/screen.c
+++ b/src/common/screen.c
@@ -684,12 +684,20 @@ void resize_screen (void)
 {
 
     if (h_version != V6) {
-
 	wp[0].x_size = h_screen_width;
+	if (wp[0].x_cursor > h_screen_width)
+	    wp[0].x_cursor = h_screen_width;
 	wp[1].x_size = h_screen_width;
+        if (wp[1].x_cursor > h_screen_width)
+            wp[1].x_cursor = h_screen_width;
 	wp[7].x_size = h_screen_width;
+        if (wp[7].x_cursor > h_screen_width)
+            wp[7].x_cursor = h_screen_width;
 
+        /*XXX This needs to be in sync with unix_resize_display. */
 	wp[0].y_size = h_screen_height - wp[1].y_size - wp[7].y_size;
+        if (wp[0].y_cursor > wp[0].y_size)
+            wp[0].y_cursor = wp[0].y_size;
     }
 
 }/* resize_screen */

--- a/src/common/screen.c
+++ b/src/common/screen.c
@@ -687,7 +687,7 @@ void resize_screen (void)
     if (h_version == V6)
         h_flags |= REFRESH_FLAG;
     else {
-        int scroll;
+        int scroll, h;
 
 	wp[0].x_size = h_screen_width;
 	if (wp[0].x_cursor > h_screen_width)
@@ -699,9 +699,17 @@ void resize_screen (void)
         if (wp[7].x_cursor > h_screen_width)
             wp[7].x_cursor = h_screen_width;
 
-        /*TODO What if this becomes negative? */
-	wp[0].y_size = h_screen_height - wp[1].y_size - wp[7].y_size;
-	scroll = wp[0].y_cursor - wp[0].y_size;
+        h = h_screen_height - wp[1].y_size - wp[7].y_size;
+        if (h > 0) {
+            wp[0].y_size = h;
+            scroll = wp[0].y_cursor - wp[0].y_size;
+        } else {
+            /* Just make a one line window at the bottom of the screen. */
+            /*XXX We should probably adjust the other windows.  But how? */
+            wp[0].y_size = 1;
+            scroll = wp[0].y_pos + wp[0].y_cursor - h_screen_height - 1;
+            wp[0].y_pos = h_screen_height;
+        }
         if (scroll > 0) {
             wp[0].y_cursor = wp[0].y_size;
             os_repaint_window(0, wp[0].y_pos + scroll, wp[0].y_pos,

--- a/src/common/screen.c
+++ b/src/common/screen.c
@@ -682,8 +682,13 @@ static void erase_screen (zword win)
  */
 void resize_screen (void)
 {
+    /* V6 games are asked to redraw.  Other versions have no means for that
+       so we do what we can. */
+    if (h_version == V6)
+        h_flags |= REFRESH_FLAG;
+    else {
+        int scroll;
 
-    if (h_version != V6) {
 	wp[0].x_size = h_screen_width;
 	if (wp[0].x_cursor > h_screen_width)
 	    wp[0].x_cursor = h_screen_width;
@@ -694,10 +699,14 @@ void resize_screen (void)
         if (wp[7].x_cursor > h_screen_width)
             wp[7].x_cursor = h_screen_width;
 
-        /*XXX This needs to be in sync with unix_resize_display. */
+        /*TODO What if this becomes negative? */
 	wp[0].y_size = h_screen_height - wp[1].y_size - wp[7].y_size;
-        if (wp[0].y_cursor > wp[0].y_size)
+	scroll = wp[0].y_cursor - wp[0].y_size;
+        if (scroll > 0) {
             wp[0].y_cursor = wp[0].y_size;
+            os_repaint_window(0, wp[0].y_pos + scroll, wp[0].y_pos,
+                              wp[0].x_pos, wp[0].y_size, wp[0].x_size);
+        }
     }
 
 }/* resize_screen */

--- a/src/common/setup.h
+++ b/src/common/setup.h
@@ -30,6 +30,7 @@ typedef struct frotz_setup_struct {
         char *aux_name;
         char *story_path;
         char *zcode_path;
+	char *restricted_path;
 	int restore_mode; /* for a save file passed from command line*/
 
 	bool use_blorb;

--- a/src/curses/ux_audio.c
+++ b/src/curses/ux_audio.c
@@ -49,9 +49,6 @@
 #include <vorbis/vorbisfile.h>
 #include <libmodplug/modplug.h>
 
-#define MAX(x,y) ((x)>(y)) ? (x) : (y)
-#define MIN(x,y) ((x)<(y)) ? (x) : (y)
-
 enum sound_type {
     FORM,
     OGGV,

--- a/src/curses/ux_blorb.h
+++ b/src/curses/ux_blorb.h
@@ -21,7 +21,8 @@ typedef struct sampledata_struct {
  */
 typedef struct {
     bb_result_t bbres;
-    ulong type;
+    // ulong type;
+    unsigned long type;
     FILE *fp;
 } myresource;
 

--- a/src/curses/ux_frotz.h
+++ b/src/curses/ux_frotz.h
@@ -5,6 +5,8 @@
  *
  */
 
+#include <signal.h>
+
 #include "defines.h"
 #include "../common/frotz.h"
 #include "../blorb/blorb.h"
@@ -78,6 +80,8 @@ extern char *gamepath;	/* use to find sound files */
 
 extern f_setup_t f_setup;
 extern u_setup_t u_setup;
+
+extern volatile sig_atomic_t terminal_resized;
 
 /*** Functions specific to the Unix port of Frotz ***/
 

--- a/src/curses/ux_frotz.h
+++ b/src/curses/ux_frotz.h
@@ -92,6 +92,7 @@ bool unix_init_pictures(void);		/* ux_pic.c */
 // void unix_save_screen(int);		/* ux_screen.c */
 // void unix_do_scrollback(void);		/* ux_screen.c */
 void unix_resize_display(void);		/* ux_screen.c */
+void unix_suspend_program(void);        /* ux_screen.c */
 void unix_get_terminal_size(void);      /* ux_init.c */
 
 

--- a/src/curses/ux_frotz.h
+++ b/src/curses/ux_frotz.h
@@ -65,6 +65,8 @@
 #define	PATH1		"ZCODE_PATH"
 #define PATH2		"INFOCOM_PATH"
 
+#define MAX(x,y) ((x)>(y)) ? (x) : (y)
+#define MIN(x,y) ((x)<(y)) ? (x) : (y)
 
 /* Some regular curses (not ncurses) libraries don't do this correctly. */
 #ifndef getmaxyx
@@ -86,11 +88,11 @@ extern volatile sig_atomic_t terminal_resized;
 /*** Functions specific to the Unix port of Frotz ***/
 
 bool unix_init_pictures(void);		/* ux_pic.c */
-bool unix_init_pictures(void);		/* ux_pic.c */
-void unix_init_scrollback(void);	/* ux_screen.c */
-void unix_save_screen(int);		/* ux_screen.c */
-void unix_do_scrollback(void);		/* ux_screen.c */
+/* void unix_init_scrollback(void);	/* ux_screen.c */
+/* void unix_save_screen(int);		/* ux_screen.c */
+/* void unix_do_scrollback(void);		/* ux_screen.c */
 void unix_resize_display(void);		/* ux_screen.c */
+void unix_get_terminal_size(void);      /* ux_init.c */
 
 
 #ifdef NO_STRRCHR

--- a/src/curses/ux_frotz.h
+++ b/src/curses/ux_frotz.h
@@ -88,9 +88,9 @@ extern volatile sig_atomic_t terminal_resized;
 /*** Functions specific to the Unix port of Frotz ***/
 
 bool unix_init_pictures(void);		/* ux_pic.c */
-/* void unix_init_scrollback(void);	/* ux_screen.c */
-/* void unix_save_screen(int);		/* ux_screen.c */
-/* void unix_do_scrollback(void);		/* ux_screen.c */
+// void unix_init_scrollback(void);	/* ux_screen.c */
+// void unix_save_screen(int);		/* ux_screen.c */
+// void unix_do_scrollback(void);		/* ux_screen.c */
 void unix_resize_display(void);		/* ux_screen.c */
 void unix_get_terminal_size(void);      /* ux_init.c */
 

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -376,6 +376,33 @@ void os_process_arguments (int argc, char *argv[])
 }/* os_process_arguments */
 
 
+void unix_get_terminal_size()
+{
+    int y, x;
+    getmaxyx(stdscr, y, x);
+
+    if (u_setup.screen_height != -1)
+        h_screen_rows = u_setup.screen_height;
+    else
+        /* 255 disables paging entirely. */
+        h_screen_rows = MIN(254, y);
+
+    if (u_setup.screen_width != -1)
+        h_screen_cols = u_setup.screen_width;
+    else
+        h_screen_cols = MIN(255, x);
+
+    if (h_screen_cols < 1)
+        os_fatal("Invalid screen width. Must be between 1 and 255.");
+
+    h_font_width = 1;
+    h_font_height = 1;
+
+    h_screen_width = h_screen_cols;
+    h_screen_height = h_screen_rows;
+}
+
+
 /*
  * os_init_screen
  *
@@ -453,21 +480,7 @@ void os_init_screen (void)
         if (f_setup.undo_slots == 0)
             h_flags &= ~UNDO_FLAG;
 
-    getmaxyx(stdscr, h_screen_rows, h_screen_cols);
-
-    if (u_setup.screen_height != -1)
-	h_screen_rows = u_setup.screen_height;
-    if (u_setup.screen_width != -1)
-	h_screen_cols = u_setup.screen_width;
-
-    h_screen_width = h_screen_cols;
-    h_screen_height = h_screen_rows;
-
-    if (h_screen_width > 255 || h_screen_width < 1)
-	os_fatal("Invalid screen width. Must be between 1 and 255.");
-
-    h_font_width = 1;
-    h_font_height = 1;
+    unix_get_terminal_size();
 
     /* Must be after screen dimensions are computed.  */
     if (h_version == V6) {

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -389,8 +389,11 @@ void unix_get_terminal_size()
     else
         h_screen_cols = MIN(255, x);
 
-    if (h_screen_cols < 1)
+    if (h_screen_cols < 1) {
+        endwin();
+        u_setup.curses_active = FALSE;
         os_fatal("Invalid screen width. Must be between 1 and 255.");
+    }
 
     h_font_width = 1;
     h_font_height = 1;

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -48,6 +48,8 @@
 f_setup_t f_setup;
 u_setup_t u_setup;
 
+volatile sig_atomic_t terminal_resized = 0;
+
 static int getconfig(char *);
 static int geterrmode(char *);
 static int getcolor(char *);
@@ -967,14 +969,14 @@ static int geterrmode(char *value)
  * sigwinch_handler
  *
  * Called whenever Frotz recieves a SIGWINCH signal to make curses
- * cleanly resize the window.
+ * cleanly resize the window.  To be safe, just set a flag here.
+ * It is checked and cleared in unix_read_char.
  *
  */
 static void sigwinch_handler(int UNUSED(sig))
 {
-  signal(SIGWINCH, SIG_IGN);
-  unix_resize_display();
-  signal(SIGWINCH, sigwinch_handler);
+    terminal_resized = 1;
+    signal(SIGWINCH, sigwinch_handler);
 }
 
 

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -45,19 +45,9 @@
 #include "ux_frotz.h"
 #include "ux_blorb.h"
 
-f_setup_t f_setup;
-u_setup_t u_setup;
-
 volatile sig_atomic_t terminal_resized = 0;
 
-static int getconfig(char *);
-static int geterrmode(char *);
-static int getcolor(char *);
-static int getbool(char *);
-
 static void sigwinch_handler(int);
-static void sigint_handler(int);
-
 #define INFORMATION "\
 An interpreter for all Infocom and other Z-Machine games.\n\
 \n\
@@ -80,6 +70,13 @@ Syntax: frotz [options] story-file\n\
 char stripped_story_name[FILENAME_MAX+1];
 char semi_stripped_story_name[FILENAME_MAX+1];
 */
+
+f_setup_t f_setup;
+u_setup_t u_setup;
+
+/* static void sigwinch_handler(int); */
+static void sigint_handler(int);
+/* static void redraw(void); */
 
 static int zgetopt (int, char **, const char *);
 static int zoptind = 1;
@@ -999,10 +996,9 @@ static void sigwinch_handler(int UNUSED(sig))
  * is not done.
  *
  */
-static void sigint_handler(int dummy)
+static void sigint_handler(int UNUSED(dummy))
 {
     signal(SIGINT, sigint_handler);
-    // dummy = dummy;
 
     os_stop_sample(0);
     scrollok(stdscr, TRUE); scroll(stdscr);

--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -440,7 +440,7 @@ void os_init_screen (void)
 	exit(1);
     }
     u_setup.curses_active = 1;	/* Let os_fatal know curses is running */
-    cbreak();			/* Raw input mode, no line processing */
+    raw();			/* Raw input mode, no line processing */
     noecho();			/* No input echo */
     nonl();			/* No newline translation */
     intrflush(stdscr, TRUE);	/* Flush output on interrupt */
@@ -548,9 +548,28 @@ void os_reset_screen (void)
     os_set_text_style(0);
     os_display_string((zchar *)"[Hit any key to exit.]\n");
     os_read_key(0, FALSE);
-    scrollok(stdscr, TRUE); scroll(stdscr);
-    refresh(); endwin();
+    os_quit();
 }/* os_reset_screen */
+
+
+/*
+ * os_quit
+ *
+ * Immediately and cleanly exit.
+ *
+ */
+void os_quit(void)
+{
+    os_stop_sample(0);
+    ux_blorb_stop();
+    if (u_setup.curses_active) {
+        scrollok(stdscr, TRUE);
+        scroll(stdscr);
+        refresh();
+        endwin();
+    }
+    exit(1);
+}/* os_quit */
 
 
 /*

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -281,6 +281,11 @@ static int unix_read_char(int extkeys)
 	case MOD_CTRL ^ 'U': c = ZC_DEL_TO_BOL; break;
 	case MOD_CTRL ^ 'W': c = ZC_DEL_WORD; break;
 
+	/* In raw mode we need to take care of this as well. */
+	case MOD_CTRL ^ 'Z':
+	    unix_suspend_program();
+	    continue;
+
 	/* use ^Q to immediately exit. */
 	case MOD_CTRL ^ 'Q': os_quit();
 

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -488,13 +488,16 @@ zchar os_read_line (int bufmax, zchar *buf, int timeout, int width,
     unix_set_global_timeout(timeout);
     for (;;) {
         int x2, max;
+        if (scrpos >= width)
+            scrpos = width - 1;
 	move(y, x + scrpos);
 	/* Maybe there's a cleaner way to do this, but refresh() is */
 	/* still needed here to print spaces.  --DG */
 	refresh();
 	ch = unix_read_char(1);
 	getyx(stdscr, y, x2);
-        max = MIN(h_screen_width - margin, bufmax);
+	width = h_screen_width - margin;
+        max = MIN(width, bufmax);
         /* The screen has shrunk and input no longer fits.  Chop. */
 	if (len > max) {
 	    len = max;

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -130,6 +130,10 @@ static int unix_read_char(int extkeys)
     int c;
 
     while(1) {
+        while (terminal_resized) {
+            terminal_resized = 0;
+            unix_resize_display();
+        }
 	timeout( timeout_to_ms());
 	c = getch();
 

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -115,6 +115,7 @@ static bool timeout_left(struct timeval *diff)
 }
 
 
+#if 0
 /*
  * Time left until input timeout.  Return the number of milliseconds left
  * until the input timeout elapses, zero if it has already elapsed, -1 if
@@ -129,6 +130,7 @@ static int timeout_to_ms()
         return INT_MAX - 1000;
     return diff.tv_sec * 1000 + diff.tv_usec / 1000;
 }
+#endif
 
 
 /*
@@ -506,6 +508,7 @@ zchar os_read_line (int bufmax, zchar *buf, int timeout, int width,
 	refresh();
 	ch = unix_read_char(1);
 	getyx(stdscr, y, x2);
+	x2++;   /*XXX Eliminate compiler warning. */
 	width = h_screen_width - margin;
         max = MIN(width, bufmax);
         /* The screen has shrunk and input no longer fits.  Chop. */

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -185,8 +185,6 @@ static int unix_read_char(int extkeys)
 	/* On many terminals the backspace key returns DEL. */
 	if (c == erasechar()) return ZC_BACKSPACE;;
 
-	if (c == killchar()) return ZC_ESCAPE;
-
 	switch(c) {
 	/* This should not happen because select said we have input. */
 	case ERR:
@@ -268,16 +266,23 @@ static int unix_read_char(int extkeys)
 	case MOD_META | 'f': return ZC_WORD_RIGHT;
 	case MOD_META | 'b': return ZC_WORD_LEFT;
 
-	/* these are the emacs-editing characters */
+	/* these are the UNIX line-editing characters */
 	case MOD_CTRL ^ 'B': return ZC_ARROW_LEFT;
+	/* use ^C to clear line anywhere it doesn't send SIGINT */
+	case MOD_CTRL ^ 'C': return ZC_ESCAPE;
 	case MOD_CTRL ^ 'F': return ZC_ARROW_RIGHT;
 	case MOD_CTRL ^ 'P': return ZC_ARROW_UP;
 	case MOD_CTRL ^ 'N': return ZC_ARROW_DOWN;
+
 	case MOD_CTRL ^ 'A': c = KEY_HOME; break;
 	case MOD_CTRL ^ 'E': c = KEY_END; break;
 	case MOD_CTRL ^ 'D': c = KEY_DC; break;
 	case MOD_CTRL ^ 'K': c = KEY_EOL; break;
+	case MOD_CTRL ^ 'U': c = ZC_DEL_TO_BOL; break;
 	case MOD_CTRL ^ 'W': c = ZC_DEL_WORD; break;
+
+	/* use ^Q to immediately exit. */
+	case MOD_CTRL ^ 'Q': os_quit();
 
 	default: break; /* Who knows? */
 	}
@@ -530,6 +535,18 @@ zchar os_read_line (int bufmax, zchar *buf, int timeout, int width,
 			for (i = len; i <= oldlen ; i++) {
 				mvaddch(y, x + i, ' ');
 			}
+		}
+		break;
+	case ZC_DEL_TO_BOL:
+		if (scrpos != 0) {
+			searchpos = -1;
+			len -= scrpos;
+			scrnmove(x, x + scrpos, len);
+			memmove(buf, buf + scrpos, len);
+			for (int i = len; i <= len + scrpos; i++) {
+				mvaddch(y, x + i, ' ');
+			}
+			scrpos = 0;
 		}
 		break;
 	case CHR_DEL:

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -130,12 +130,12 @@ static int unix_read_char(int extkeys)
     int c;
 
     while(1) {
+	timeout( timeout_to_ms());
+	c = getch();
         while (terminal_resized) {
             terminal_resized = 0;
             unix_resize_display();
         }
-	timeout( timeout_to_ms());
-	c = getch();
 
 	/* Catch 98% of all input right here... */
 	if ((c >= ZC_ASCII_MIN && c <= ZC_ASCII_MAX)

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -259,8 +259,7 @@ static int unix_read_char(int extkeys)
 	 * to use one of the emacs keys that isn't implemented and he
 	 * gets a random hot key function.  It's less jarring to catch
 	 * them and do nothing.  [APP] */
-      if ((c >= ZC_HKEY_MIN) && (c <= ZC_HKEY_MAX))
-	continue;
+      if ((c >= ZC_HKEY_MIN) && (c <= ZC_HKEY_MAX)) continue;
 
 	/* Finally, if we're in full line mode (os_read_line), we
 	   might return codes which aren't legal Z-machine keys but
@@ -652,6 +651,8 @@ int os_read_file_name (char *file_name, const char *default_name, int UNUSED(fla
 {
     int saved_replay = istream_replay;
     int saved_record = ostream_record;
+    int i;
+    char *tempname;
 
     /* Turn off playback and recording temporarily */
 
@@ -674,6 +675,23 @@ int os_read_file_name (char *file_name, const char *default_name, int UNUSED(fla
 
     if (file_name[0] == 0)
         strcpy (file_name, default_name);
+
+    /* Check if we're restricted to one directory. */
+
+    if (f_setup.restricted_path != NULL) {
+	for (i = strlen(file_name); i > 0; i--) {
+	    if (file_name[i] == PATH_SEPARATOR) {
+		i++;
+		break;
+	    }
+	}
+	tempname = strdup(file_name + i);
+	strcpy(file_name, f_setup.restricted_path);
+	if (file_name[strlen(file_name)-1] != PATH_SEPARATOR) {
+	    strcat(file_name, "/");
+	}
+	strcat(file_name, tempname);
+    }
 
     /* Restore state of playback and recording */
 

--- a/src/curses/ux_params.txt
+++ b/src/curses/ux_params.txt
@@ -1,0 +1,26 @@
+-a   watch attribute setting
+-A   watch attribute testing
+-b <colorname> background color
+-c # context lines
+-d   disable color
+-e   enable sound
+-f <colorname> foreground color
+-F   Force color mode
+-h # screen height
+-i   ignore fatal errors
+-l # left margin
+-L <file> load this save file
+-o   watch object movement
+-O   watch object locating
+-p   plain ASCII output only
+-P   alter piracy opcode
+-q   quiet (disable sound effects)
+-r # right margin
+-R <path> restricted read/write
+-s # random number seed value
+-S # transcript width
+-t   set Tandy bit
+-u # slots for multiple undo
+-v   show version information
+-w # screen width
+-x   expand abbreviations g/x/z

--- a/src/curses/ux_resource.c
+++ b/src/curses/ux_resource.c
@@ -23,7 +23,8 @@ bb_map_t *blorb_map;
 int ux_getresource( int num, int ispic, int method, myresource * res)
 {
     int st;
-    ulong usage;
+    // ulong usage;
+    unsigned long usage;
 
     res->bbres.data.ptr = NULL;
     res->fp = NULL;

--- a/src/curses/ux_screen.c
+++ b/src/curses/ux_screen.c
@@ -144,7 +144,10 @@ void os_scroll_area (int top, int left, int bottom, int right, int units)
  */
 void unix_resize_display(void)
 {
-    int x, y;
+//    int x, y;
+
+    endwin();
+    refresh();
 
     /* Notify the game that the display needs refreshing */
     if (h_version == V6)
@@ -163,9 +166,6 @@ void unix_resize_display(void)
 	resize_screen();
 	restart_header();
     }
-
-    endwin();
-    refresh();
 
 //    clearok(stdscr, 1);
 //    redrawwin(stdscr);

--- a/src/curses/ux_screen.c
+++ b/src/curses/ux_screen.c
@@ -33,9 +33,7 @@
 
 #include "ux_frotz.h"
 
-extern void resize_screen(void);
 extern void restart_header(void);
-extern void restart_screen(void);
 
 static WINDOW *saved_screen = NULL;
 
@@ -188,7 +186,7 @@ bool os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
 {
     int lines, cols;
     if (!saved_screen)
-        return false;
+        return FALSE;
     getmaxyx(saved_screen, lines, cols);
     ypos_old--, ypos_new--, xpos--;
     if (xpos + xsize > cols)
@@ -207,7 +205,7 @@ bool os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
             move(y, x);
     }
     if (xsize <= 0 || ysize <= 0)
-        return false;
+        return FALSE;
     return copywin(saved_screen, stdscr, ypos_old, xpos, ypos_new, xpos,
                    ypos_new + ysize - 1, xpos + xsize - 1, FALSE) != ERR;
 }

--- a/src/curses/ux_screen.c
+++ b/src/curses/ux_screen.c
@@ -211,20 +211,15 @@ void unix_resize_display(void)
     endwin();
     refresh();
     unix_get_terminal_size();
-
     if (lines > h_screen_rows) {
-        /* Lose some of the topmost lines that won't fit. */
-        int lost = lines - h_screen_rows;
-        /* Don't lose the cursor position though,
-           drop some trailing lines instead. */
-        if (y < lost)
-            lost = y;
         lines = h_screen_rows;
-        y -= lost;
-        pos += cols * lost;
+        if (y >= h_screen_rows) {
+            /* Lose some topmost lines to keep the cursor on screen. */
+            int lost = y + 1 - h_screen_rows;
+            y = h_screen_rows - 1;
+            pos += cols * lost;
+        }
     }
-    if (y >= h_screen_rows)
-        y = h_screen_rows - 1;
     if (x >= h_screen_cols)
         x = h_screen_cols - 1;
     restore_screen(lines, cols, pos);

--- a/src/curses/ux_screen.c
+++ b/src/curses/ux_screen.c
@@ -144,32 +144,16 @@ void os_scroll_area (int top, int left, int bottom, int right, int units)
  */
 void unix_resize_display(void)
 {
-//    int x, y;
-
     endwin();
     refresh();
+    unix_get_terminal_size();
 
     /* Notify the game that the display needs refreshing */
     if (h_version == V6)
 	h_flags |= REFRESH_FLAG;
 
-    /* Get new terminal dimensions */
-//    getmaxyx(stdscr, y, x);
-
-    /* Update the game's header */
-    h_screen_width  = (zword) COLS;
-    h_screen_height = (zword) LINES;
-    h_screen_cols   = (zbyte) (h_screen_width / h_font_width);
-    h_screen_rows   = (zbyte)(h_screen_height / h_font_height);
-
     if (zmp != NULL) {
 	resize_screen();
 	restart_header();
     }
-
-//    clearok(stdscr, 1);
-//    redrawwin(stdscr);
-//    refresh();
-//    clearok(stdscr, 0);
-
 }/* unix_redraw_display */

--- a/src/curses/ux_screen.c
+++ b/src/curses/ux_screen.c
@@ -37,6 +37,8 @@ extern void resize_screen(void);
 extern void restart_header(void);
 extern void restart_screen(void);
 
+static WINDOW *saved_screen = NULL;
+
 /*
  * os_erase_area
  *
@@ -137,61 +139,6 @@ void os_scroll_area (int top, int left, int bottom, int right, int units)
 
 
 /*
- * Copy the screen into a buffer.  The buffer must be at least
- * cols * lines + 1 elements long and will contain the top left part of
- * the screen with the given dimensions.  Line n on the screen will start
- * at position col * n in the array.
- *
- * Reading stops on error, typically if the screen has fewer lines than
- * requested.  If n lines were successfully read, a zero is written at
- * position cols * n of the array (hence the size requirement).  If the
- * screen has fewer columns than requested, lines are read up to the last
- * column.  They may or may not be terminated by zero - it depends on
- * the curses implementation.
- *
- * The cursor position is affected.  The number of successfully read lines
- * is returned.
- */
-static int save_screen(int lines, int cols, chtype *buf)
-{
-    int li;
-    for (li = 0; li < lines; ++li)
-        if (ERR == mvinchnstr(li, 0, buf + li * cols, cols))
-            break;
-    buf[li * cols] = 0;
-    return li;
-}
-
-
-/*
- * Restore the screen from a buffer.  This is the inverse of save_screen.
- * The buffer must be at least cols * lines elements long.  See save_screen
- * about the layout.
- *
- * The screen is cleared first.  Areas are left blank if the buffer has
- * fewer columns or lines than the screen.  If the buffer has more columns
- * or lines than the screen, the leftmost columns and topmost lines are
- * printed, as much as will fit.  (This is probably what you want for
- * columns but not for lines, so add an appropriate offset to buf.)
- *
- * Writing stops early if a line in buf starts with zero or if there is an
- * error.  The cursor position is affected.  Returns the number of successfully
- * written lines.
- */
-static int restore_screen(int lines, int cols, const chtype *buf)
-{
-    int li, n = MIN(lines, LINES);
-    clear();
-    for (li = 0; li < n; ++li) {
-        const chtype *p = buf + li * cols;
-        if (!*p || ERR == mvaddchnstr(li, 0, p, cols))
-            break;
-    }
-    return li;
-}
-
-
-/*
  * unix_resize_display
  *
  * Resize the display and redraw.
@@ -199,14 +146,15 @@ static int restore_screen(int lines, int cols, const chtype *buf)
  */
 void unix_resize_display(void)
 {
-    int x, y,
+    int x, y, start = 0,
         lines = h_screen_rows, cols = h_screen_cols;
-    chtype
-        *const buf = malloc(sizeof(chtype) * (cols * lines + 1)),
-        *pos = buf;
 
+    if ((saved_screen = newpad(lines, cols))
+        && overwrite(stdscr, saved_screen) == ERR) {
+        delwin(saved_screen);
+        saved_screen = NULL;
+    }
     getyx(stdscr, y, x);
-    lines = save_screen(lines, cols, buf);
 
     endwin();
     refresh();
@@ -215,16 +163,19 @@ void unix_resize_display(void)
         lines = h_screen_rows;
         if (y >= h_screen_rows) {
             /* Lose some topmost lines to keep the cursor on screen. */
-            int lost = y + 1 - h_screen_rows;
+            start = y + 1 - h_screen_rows;
             y = h_screen_rows - 1;
-            pos += cols * lost;
         }
     }
+    if (cols > h_screen_cols)
+        cols = h_screen_cols;
     if (x >= h_screen_cols)
         x = h_screen_cols - 1;
-    restore_screen(lines, cols, pos);
-    free(buf);
+    if (saved_screen)
+        copywin(saved_screen, stdscr, start, 0, 0, 0,
+                lines - 1, cols - 1, FALSE);
     move(y, x);
+    refresh();
 
     /* Notify the game that the display needs refreshing */
     if (h_version == V6)
@@ -233,5 +184,9 @@ void unix_resize_display(void)
     if (zmp != NULL) {
 	resize_screen();
 	restart_header();
+    }
+    if (saved_screen) {
+        delwin(saved_screen);
+        saved_screen = NULL;
     }
 }/* unix_redraw_display */

--- a/src/curses/ux_screen.c
+++ b/src/curses/ux_screen.c
@@ -187,6 +187,8 @@ bool os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
     int lines, cols;
     if (!saved_screen)
         return FALSE;
+    if (xsize == 0 || ysize == 0)
+        return TRUE;
     getmaxyx(saved_screen, lines, cols);
     ypos_old--, ypos_new--, xpos--;
     if (xpos + xsize > cols)

--- a/src/curses/ux_text.c
+++ b/src/curses/ux_text.c
@@ -277,14 +277,13 @@ int os_char_width (zchar c)
 
         int width = 0;
         const char *ptr = latin1_to_ascii + 3 * (c - ZC_LATIN1_MIN);
-	char c1 = *ptr++;
-	char c2 = *ptr++;
-	char c3 = *ptr++;
+	char c2, c3;
 
-	/* Why, oh, why did you declare variables that way??? */
+	ptr++;
+	c2 = *ptr++;
+	c3 = *ptr++;
 
-	if (c1 == c1)  /* let's avoid confusing the compiler (and me) */
-	  width++;
+	width++;
 	if (c2 != ' ')
 	  width++;
 	if (c3 != ' ')

--- a/src/dos/bcinit.c
+++ b/src/dos/bcinit.c
@@ -21,19 +21,19 @@ static char information[] =
 "Complies with standard 1.0 of Graham Nelson's specification.\n"
 "\n"
 "Syntax: frotz [options] story-file\n"
-"  -a   watch attribute setting  \t -o   watch object movement\n"
-"  -A   watch attribute testing  \t -O   watch object locating\n"
-"  -b # background colour        \t -p   alter piracy opcode\n"
-"  -B # reverse background colour\t -r # right margin\n"
-"  -c # context lines            \t -s # random number seed value\n"
-"  -d # display mode (see below) \t -S # transscript width\n"
-"  -e # emphasis colour [mode 1] \t -t   set Tandy bit\n"
-"  -f # foreground colour        \t -T   bold typing [modes 2+4+5]\n"
-"  -F # reverse foreground colour\t -u # slots for multiple undo\n"
-"  -g # font [mode 5] (see below)\t -w # screen width\n"
-"  -h # screen height            \t -x   expand abbreviations g/x/z\n"
-"  -i   ignore runtime errors    \t -Z # error checking (see below)\n"
-"  -l # left margin"
+"  -a   watch attribute setting    \t -o   watch object movement\n"
+"  -A   watch attribute testing    \t -O   watch object locating\n"
+"  -b # background colour          \t -p   alter piracy opcode\n"
+"  -B # reverse background colour  \t -r # right margin\n"
+"  -c # context lines              \t -R <path> restricted read/write\n"
+"  -d # display mode (see below)   \t -s # random number seed value\n"
+"  -e # emphasis colour [mode 1]   \t -S # transscript width\n"
+"  -f # foreground colour          \t -t   set Tandy bit\n"
+"  -F # reverse foreground colour  \t -T   bold typing [modes 2+4+5]\n"
+"  -g # font [mode 5] (see below)  \t -u # slots for multiple undo\n"
+"  -h # screen height              \t -w # screen width\n"
+"  -i   ignore runtime errors      \t -x   expand abbreviations g/x/z\n"
+"  -l # left margin                \t -Z # error checking (see below)"
 "\n"
 "Fonts are 0 (fixed), 1 (sans serif), 2 (comic), 3 (times), 4 (serif).\n"
 "Display modes are 0 (mono), 1 (text), 2 (CGA), 3 (MCGA), 4 (EGA), 5 (Amiga)."
@@ -261,7 +261,7 @@ static void parse_options (int argc, char **argv)
 
 	int num = 0;
 
-	c = getopt (argc, argv, "aAb:B:c:d:e:f:F:g:h:il:oOpr:s:S:tTu:w:xZ:");
+	c = getopt (argc, argv, "aAb:B:c:d:e:f:F:g:h:il:oOpr:R:s:S:tTu:w:xZ:");
 
 	if (optarg != NULL)
 	    num = dectoi (optarg);
@@ -309,6 +309,8 @@ static void parse_options (int argc, char **argv)
 	    f_setup.piracy = 1;
 	if (c == 'r')
 	    f_setup.right_margin = num;
+	if (c == 'R')
+	    f_setup.restricted_path = strdup(optarg);
 	if (c == 's')
 	    user_random_seed = num;
 	if (c == 'S')

--- a/src/dos/bcinput.c
+++ b/src/dos/bcinput.c
@@ -928,6 +928,9 @@ int os_read_file_name (char *file_name, const char *default_name, int flag)
     bool saved_replay = istream_replay;
     bool saved_record = ostream_record;
 
+    int i;
+    char *tempname;
+
     /* Turn off playback and recording temporarily */
 
     istream_replay = FALSE;
@@ -960,6 +963,23 @@ int os_read_file_name (char *file_name, const char *default_name, int flag)
 	strcpy (file_name, default_name);
     if (strchr (file_name, '.') == NULL)
 	strcat (file_name, extension);
+
+    /* FIXME: UNTESTED Check if we're restricted to one directory. */
+
+    if (f_setup.restricted_path != NULL) {
+	for (i = strlen(file_name); i > 0; i--) {
+	    if (file_name[i] == PATH_SEPARATOR) {
+		i++;
+		break;
+	    }
+	}
+	tempname = strdup(file_name + i);
+	strcpy(file_name, f_setup.restricted_path);
+	if (file_name[strlen(file_name)-1] != PATH_SEPARATOR) {
+	    strcat(file_name, "\\");
+	}
+	strcat(file_name, tempname);
+    }
 
     /* Make sure it is safe to use this file name */
 

--- a/src/dos/bcparams.txt
+++ b/src/dos/bcparams.txt
@@ -1,0 +1,26 @@
+-a   watch attribute setting
+-A   watch attribute testing
+-b # background colour
+-B # reverse background colour
+-c # context lines
+-d # display mode (see below)
+-e # emphasis colour [mode 1]
+-f # foreground colour
+-F # reverse foreground colour
+-g # font [mode 5] (see below)
+-h # screen height
+-i   ignore runtime errors
+-l # left margin
+-o   watch object movement
+-O   watch object locating
+-p   alter piracy opcode
+-r # right margin
+-R <path> restricted read/write
+-s # random number seed value
+-S # transscript width
+-t   set Tandy bit
+-T   bold typing [modes 2+4+5]
+-u # slots for multiple undo
+-w # screen width
+-x   expand abbreviations g/x/z
+-Z # error checking (see below)

--- a/src/dos/bcsample.c
+++ b/src/dos/bcsample.c
@@ -123,6 +123,23 @@ static void interrupt end_of_dma (void)
 
 }/* end_of_dma */
 
+
+/*
+ * os_init_sound
+ *
+ * Dummy function to satisfy the core code.  DOS Frotz does its sound
+ * initialization in bcinit.c in os_init_screen().
+ *
+ * FIXME: Move the sound initlization from os_init_screen() to here and
+ *        somehow work around the ifs.
+ *
+ */
+void os_init_sound(void)
+{
+	/* do nothing */
+}
+
+
 /*
  * dos_init_sound
  *
@@ -331,6 +348,8 @@ void os_prepare_sample (int number)
 void os_start_sample (int number, int volume, int repeats, zword eos)
 {
 #ifdef SOUND_SUPPORT
+
+    eos=eos;	/* not used in DOS Frotz */
 
     os_stop_sample ();
 

--- a/src/dos/bcscreen.c
+++ b/src/dos/bcscreen.c
@@ -301,3 +301,9 @@ void os_scroll_area (int top, int left, int bottom, int right, int units)
 		    clear_line (y, left, right);
 
 }/* os_scroll_area */
+
+bool os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
+                       int ysize, int xsize)
+{
+    return FALSE;
+}

--- a/src/dumb/dumb_init.c
+++ b/src/dumb/dumb_init.c
@@ -32,16 +32,16 @@ static void print_version(void);
 An interpreter for all Infocom and other Z-Machine games.\n\
 \n\
 Syntax: dfrotz [options] story-file\n\
-  -a   watch attribute setting   \t -R <filename> load this save file\n\
-  -A   watch attribute testing   \t -s # random number seed value\n\
-  -h # screen height             \t -S # transcript width\n\
-  -i   ignore fatal errors       \t -t   set Tandy bit\n\
-  -I # interpreter number        \t -u # slots for multiple undo\n\
-  -o   watch object movement     \t -v show version information\n\
-  -O   watch object locating     \t -w # screen width\n\
-  -p   plain ASCII output only   \t -x   expand abbreviations g/x/z\n\
-  -P   alter piracy opcode \n\
-  -r xxx set runtime option \\xxx before starting (can be used repeatedly)\n"
+  -a   watch attribute setting    \t -P   alter piracy opcode\n\
+  -A   watch attribute testing    \t -R <path> restricted read/write\n\
+  -h # screen height              \t -s # random number seed value\n\
+  -i   ignore fatal errors        \t -S # transcript width\n\
+  -I # interpreter number         \t -t   set Tandy bit\n\
+  -o   watch object movement      \t -u # slots for multiple undo\n\
+  -O   watch object locating      \t -v   show version information\n\
+  -L <file> load this save file   \t -w # screen width\n\
+  -m   turn off MORE prompts      \t -x   expand abbreviations g/x/z\n\
+  -p   plain ASCII output only\n"
 
 /* A unix-like getopt, but with the names changed to avoid any problems.  */
 static int zoptind = 1;
@@ -95,22 +95,23 @@ void os_process_arguments(int argc, char *argv[])
     do_more_prompts = TRUE;
     /* Parse the options */
     do {
-	c = zgetopt(argc, argv, "-aAh:iI:moOpPs:r:R:S:tu:vw:xZ:");
+	c = zgetopt(argc, argv, "-aAh:iI:L:moOpPs:r:R:S:tu:vw:xZ:");
 	switch(c) {
 	  case 'a': f_setup.attribute_assignment = 1; break;
 	  case 'A': f_setup.attribute_testing = 1; break;
 	case 'h': user_screen_height = atoi(zoptarg); break;
 	  case 'i': f_setup.ignore_errors = 1; break;
 	  case 'I': f_setup.interpreter_number = atoi(zoptarg); break;
+	case 'L': f_setup.restore_mode = 1;
+		  f_setup.tmp_save_name = my_strdup(zoptarg);
+		  break;
 	  case 'm': do_more_prompts = FALSE; break;
 	  case 'o': f_setup.object_movement = 1; break;
 	  case 'O': f_setup.object_locating = 1; break;
 	  case 'P': f_setup.piracy = 1; break;
 	case 'p': plain_ascii = 1; break;
-	case 'R': f_setup.restore_mode = 1;
-		  f_setup.tmp_save_name = my_strdup(zoptarg);
-		  break;
 	case 'r': dumb_handle_setting(zoptarg, FALSE, TRUE); break;
+	case 'R': f_setup.restricted_path = strndup(zoptarg, PATH_MAX); break;
 	case 's': user_random_seed = atoi(zoptarg); break;
 	  case 'S': f_setup.script_cols = atoi(zoptarg); break;
 	case 't': user_tandy_bit = 1; break;
@@ -164,6 +165,10 @@ void os_process_arguments(int argc, char *argv[])
     f_setup.script_name = malloc(strlen(f_setup.story_name) * sizeof(char) + 5);
     strncpy(f_setup.script_name, f_setup.story_name, strlen(f_setup.story_name));
     strncat(f_setup.script_name, EXT_SCRIPT, strlen(EXT_SCRIPT));
+
+    f_setup.command_name = malloc((strlen(f_setup.story_name) + strlen(EXT_COMMAND)) * sizeof(char) + 1);
+    strncpy(f_setup.command_name, f_setup.story_name, strlen(f_setup.story_name) + 1);
+    strncat(f_setup.command_name, EXT_COMMAND, strlen(EXT_COMMAND));
 }
 
 void os_init_screen(void)

--- a/src/dumb/dumb_input.c
+++ b/src/dumb/dumb_input.c
@@ -405,6 +405,8 @@ int os_read_file_name (char *file_name, const char *default_name, int flag)
 {
   char buf[INPUT_BUFFER_SIZE], prompt[INPUT_BUFFER_SIZE];
   FILE *fp;
+  char *tempname;
+  int i;
 
   /* If we're restoring a game before the interpreter starts,
    * our filename is already provided.  Just go ahead silently.
@@ -422,6 +424,22 @@ int os_read_file_name (char *file_name, const char *default_name, int flag)
   }
 
   strcpy (file_name, buf[0] ? buf : default_name);
+
+  /* Check if we're restricted to one directory. */
+  if (f_setup.restricted_path != NULL) {
+    for (i = strlen(file_name); i > 0; i--) {
+      if (file_name[i] == PATH_SEPARATOR) {
+        i++;
+        break;
+      }
+    }
+    tempname = strdup(file_name + i);
+    strcpy(file_name, f_setup.restricted_path);
+    if (file_name[strlen(file_name)-1] != PATH_SEPARATOR) {
+      strcat(file_name, "/");
+    }
+    strcat(file_name, tempname);
+  }
 
   /* Warn if overwriting a file.  */
   if ((flag == FILE_SAVE || flag == FILE_SAVE_AUX || flag == FILE_RECORD)

--- a/src/dumb/dumb_output.c
+++ b/src/dumb/dumb_output.c
@@ -116,9 +116,11 @@ void os_set_cursor(int row, int col)
 	cursor_row = h_screen_rows - 1;
 }
 
-void os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
+bool os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
                        int ysize, int xsize)
-{}
+{
+    return FALSE;
+}
 
 /* Set a cell and update screen_changes.  */
 static void dumb_set_cell(int row, int col, cell c)

--- a/src/dumb/dumb_output.c
+++ b/src/dumb/dumb_output.c
@@ -116,8 +116,9 @@ void os_set_cursor(int row, int col)
 	cursor_row = h_screen_rows - 1;
 }
 
-bool os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
-                       int ysize, int xsize)
+bool os_repaint_window(int UNUSED(win), int UNUSED(ypos_old),
+                       int UNUSED(ypos_new), int UNUSED(xpos),
+                       int UNUSED(ysize), int UNUSED(xsize))
 {
     return FALSE;
 }

--- a/src/dumb/dumb_output.c
+++ b/src/dumb/dumb_output.c
@@ -116,6 +116,10 @@ void os_set_cursor(int row, int col)
 	cursor_row = h_screen_rows - 1;
 }
 
+void os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
+                       int ysize, int xsize)
+{}
+
 /* Set a cell and update screen_changes.  */
 static void dumb_set_cell(int row, int col, cell c)
 {

--- a/src/dumb/dumb_params.txt
+++ b/src/dumb/dumb_params.txt
@@ -1,0 +1,19 @@
+-a   watch attribute setting
+-A   watch attribute testing
+-h # screen height
+-i   ignore fatal errors
+-I # interpreter number
+-o   watch object movement
+-O   watch object locating
+-L <file> load this save file
+-m   turn off MORE prompts
+-p   plain ASCII output only
+-P   alter piracy opcode
+-R <path> restricted read/write
+-s # random number seed value
+-S # transcript width
+-t   set Tandy bit
+-u # slots for multiple undo
+-v   show version information
+-w # screen width
+-x   expand abbreviations g/x/z

--- a/src/misc/twocol.pl
+++ b/src/misc/twocol.pl
@@ -1,0 +1,60 @@
+#!/usr/bin/perl -w
+
+# This script is intended to speed up the process of adding new command 
+# line parameters to the "help" output of text-mode programs.  Most 
+# people want to have the progression of parameters go down the left 
+# column and then down the right.  Prior to using this script, put your 
+# parameter descriptions in a text file, one parameter per line.  Figure 
+# out where you want the column to end and put that number in $middle.  
+# This will cause the output to skip over that many spaces and then the 
+# second column will begin.
+#
+# When you're all set up, run this script and give the filename of your 
+# parameter text file.  Your parameters, formatted into two columns with 
+# a '\t' for the tab in the middle, will be printed to STDOUT.  Now you 
+# can put that text into a #define or a really long printf().
+#
+# In short, if your parameters file looks like this:
+#   A
+#   B
+#   C
+#   D
+# You'll get this:
+#   A   \t   C\n\
+#   B   \t   D\n\
+#
+# I've seen scripts that do this before and forgot where they were, so I 
+# made this one from scratch.  Wherever you find it, please feel free to 
+# incorporate it into whatever project you feel appropriate.  I release 
+# all rights to it to the public domain.
+#
+# Written in June 2017 by David Griffith <dave@661.org>
+#
+
+use POSIX;
+
+my @lines;
+my $leftside;
+my $middle = 34;	# put a tab in the 35th column
+my $skip;
+
+open(INFILE, "<$ARGV[0]");
+chomp(@lines = <INFILE>);
+close(INFILE);	
+
+@lines = grep(/\S/, @lines);
+
+if (scalar @lines % 2 == 1) { push @lines, ""; } 
+
+$leftsize = ceil(scalar @lines / 2);
+for (my $i = 0; $i < $leftsize; $i++) {
+	$skip = $middle - (2 + length($lines[$i]));
+	print "  $lines[$i]";
+	if ($lines[$i + $leftsize] eq "") {
+		print "\\n\n";
+	} else {
+		print " " x $skip . "\\t $lines[$i + $leftsize]\\n\\\n";
+	}
+}
+
+


### PR DESCRIPTION
Resizing now works fairly well in my testing, mostly with Beyond Zork and some other V5 games. Curses automatically reprints from the top left. For the lower window that works poorly when the number of rows shrinks. To fix that `resize_screen` restores the lower window so that the old cursor position remains on screen. Effectively it scrolls up so that the cursor ends up on the last row. 

Only the lower window height is adjusted. If there is no space left for the lower window, it is resized to one row and placed at the bottom of the screen, overlapping whatever is there. In theory that should help finish the current input line, after which the game could notice the screen resize and adjust the top window accordingly. Fat chance of that with Beyond Zork. Better not resize it so that the top part does not fit.

None of this complicated stuff is done for V6 games. We just set the refresh flag and hope that the game sorts out its windows. If it doesn't or until it gets a chance to, it's just the curses top left reprint. I haven't tested with V6 games at all.

I had to add a new interface function `os_repaint_window`, which I am not too happy about. However, it seems the least messy alternative. I added dummy versions of the new function to dfrotz and the dos version, although I don't even have a compiler for the latter.

Both SIGWINCH and ^Z are handled. There may be bugs but they'll likely need more eyeballs than mine to find.

Fixes #42.
