### PR TITLE
remove dfrotz build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ frotz: $(SRCDIR)/frotz_common.a $(SRCDIR)/frotz_curses.a $(SRCDIR)/blorblib.a
 	$(CC) $(CFLAGS) $^ -o $@$(EXTENSION) $(CURSES) $(LDFLAGS)
 
 dfrotz:  $(SRCDIR)/frotz_common.a $(SRCDIR)/frotz_dumb.a $(SRCDIR)/blorblib.a
-	$(CC) $(CFLAGS) $^ -o $@$(EXTENSION) $(LDFLAGS)
+	$(CC) $(CFLAGS) $^ -o $@$(EXTENSION)
 
 # Libs
 


### PR DESCRIPTION
As the intention of dfrotz is be dependency free, make it so at build time as well.