### PR TITLE
SDL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 frotz
 dfrotz
+sfrotz
+*.d
 *.o
 *.O
 *.OBJ

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ endif
 export CFLAGS
 
 # Enable compiler warnings. This is an absolute minimum.
-CFLAGS += -Wall -Wextra -std=gnu99
+CFLAGS += -Wall -std=c99 #-Wextra 
+
+# strdup, strndup
+CFLAGS += -D_POSIX_C_SOURCE=200809L
 
 # Define your optimization flags.
 #
@@ -66,6 +69,7 @@ DEFAULT_CONVERTER ?= SRC_SINC_MEDIUM_QUALITY
 
 ifeq ($(SOUND), ao)
 	LDFLAGS += -lao -ldl -lpthread -lm -lsndfile -lvorbisfile -lmodplug -lsamplerate
+	CFLAGS += -pthread
 else ifeq ($(SOUND), none)
 	CFLAGS += -DNO_SOUND
 else ifndef SOUND

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ else
 	GIT_TAG = $(VERSION)
 endif
 
+export CFLAGS
+
 # Enable compiler warnings. This is an absolute minimum.
 CFLAGS += -Wall -Wextra -std=gnu99
 

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ BLORB_OBJECT =  $(BLORB_DIR)/blorblib.o
 SDL_DIR = $(SRCDIR)/sdl
 SDL_LIB = $(SDL_DIR)/frotz_sdl.a
 export SDL_PKGS = libpng libjpeg sdl SDL_mixer freetype2 zlib
-SDL_LDFLAGS = `pkg-config $(SDL_PKGS) --libs` -lz
+SDL_LDFLAGS = `pkg-config $(SDL_PKGS) --libs`
 
 OBJECTS = $(COMMON_OBJECT) $(CURSES_OBJECT) $(DUMB_OBJECT) $(BLORB_OBJECT)
 

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ SUB_CLEAN = $(SUBDIRS:%=%-clean)
 
 all: frotz dfrotz sfrotz
 
-$(SDL_LIB): | $(SDL_DIR)
+$(SDL_LIB): $(SDL_DIR);
 
 $(SUBDIRS):
 	$(MAKE) -C $@

--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -5,6 +5,9 @@
  *
  */
 
+#ifndef FROTZ_H_
+#define FROTZ_H_
+
 /* Unfortunately, frotz's bool definition conflicts with that of curses.
    But since no os_* function uses it, it's safe to let the frotz core see
    this definition, but have the unix port see the curses version. */
@@ -812,3 +815,5 @@ void    resize_screen(void);
 /* This is callable only from resize_screen. */
 bool    os_repaint_window (int win, int ypos_old, int ypos_new, int xpos,
                            int ysize, int xsize);
+
+#endif

--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -750,6 +750,15 @@ void 	branch (bool);
 void	storeb (zword, zbyte);
 void	storew (zword, zword);
 
+void end_of_sound (zword routine);
+
+int completion (const zchar *buffer, zchar *result);
+
+bool is_terminator (zchar);
+void read_string (int max, zchar *buffer);
+bool read_yes_or_no (const char *);
+
+void screen_new_line (void);
 
 	/*** returns the current window ***/
 Zwindow * curwinrec( void);

--- a/src/common/frotz.h
+++ b/src/common/frotz.h
@@ -750,7 +750,7 @@ void 	branch (bool);
 void	storeb (zword, zbyte);
 void	storew (zword, zword);
 
-void end_of_sound (zword routine);
+void end_of_sound (void);
 
 int completion (const zchar *buffer, zchar *result);
 
@@ -799,6 +799,12 @@ int  	os_string_width (const zchar *);
 void	os_init_setup (void);
 void 	os_warn (const char *, ...);
 void	os_quit (void);
+
+/**
+ * Called regularly by the interpreter, at least every few instructions
+ * (only when interpreting: e.g., not when waiting for input).
+ */
+void    os_tick (void);
 
 /* Front ends call this if the terminal size changes. */
 void    resize_screen(void);

--- a/src/common/process.c
+++ b/src/common/process.c
@@ -306,10 +306,11 @@ void interpret (void)
 	}
 
 #if defined(DJGPP) && defined(SOUND_SUPPORT)
-    if (end_of_sound_flag)
-	end_of_sound ();
+        if (end_of_sound_flag)
+            end_of_sound ();
 #endif
 
+        os_tick();
     } while (finished == 0);
 
     finished--;

--- a/src/common/screen.c
+++ b/src/common/screen.c
@@ -39,6 +39,7 @@ static struct {
     {   UNKNOWN,  0,   0,   0 }
 };
 
+/* These are usually out of date.  Always update before using. */
 static int font_height = 1;
 static int font_width = 1;
 
@@ -225,6 +226,7 @@ void screen_new_line (void)
 
     cwp->x_cursor = cwp->left + 1;
 
+    os_font_data(0, &font_height, &font_width);
     if (cwp->y_cursor + 2 * font_height - 1 > cwp->y_size)
 
 	if (enable_scrolling) {
@@ -402,6 +404,7 @@ void screen_erase_input (const zchar *buf)
 	y = cwp->y_pos + cwp->y_cursor - 1;
 	x = cwp->x_pos + cwp->x_cursor - 1;
 
+	os_font_data(0, &font_height, &font_width);
 	os_erase_area (y, x, y + font_height - 1, x + width - 1, -1);
 	os_set_cursor (y, x);
 
@@ -995,6 +998,7 @@ void z_erase_line (void)
     y = cwp->y_pos + cwp->y_cursor - 1;
     x = cwp->x_pos + cwp->x_cursor - 1;
 
+    os_font_data(0, &font_height, &font_width);
     os_erase_area (y, x, y + font_height - 1, x + pixels - 1, -1);
 
 }/* z_erase_line */
@@ -1223,7 +1227,7 @@ void z_print_table (void)
 	if (i != 0) {
 
 	    flush_buffer ();
-
+	    os_font_data(0, &font_height, &font_width);
 	    cwp->y_cursor += font_height;
 	    cwp->x_cursor = x;
 

--- a/src/common/sound.c
+++ b/src/common/sound.c
@@ -31,6 +31,8 @@
 
 extern int direct_call (zword);
 
+static zword routine = 0;
+
 static int next_sample = 0;
 static int next_volume = 0;
 
@@ -74,6 +76,7 @@ static void start_sample (int number, int volume, int repeats, zword eos)
 
     os_start_sample (number, volume, repeats, eos);
 
+    routine = eos;
     playing = TRUE;
 
 }/* start_sample */
@@ -106,7 +109,7 @@ static void start_next_sample (void)
  * interrupt (which requires extremely careful programming).
  *
  */
-void end_of_sound (zword routine)
+void end_of_sound (void)
 {
 #if defined(DJGPP) && defined(SOUND_SUPPORT)
     end_of_sound_flag = 0;

--- a/src/common/sound.c
+++ b/src/common/sound.c
@@ -31,8 +31,6 @@
 
 extern int direct_call (zword);
 
-static zword routine = 0;
-
 static int next_sample = 0;
 static int next_volume = 0;
 
@@ -76,7 +74,6 @@ static void start_sample (int number, int volume, int repeats, zword eos)
 
     os_start_sample (number, volume, repeats, eos);
 
-    routine = eos;
     playing = TRUE;
 
 }/* start_sample */
@@ -109,7 +106,7 @@ static void start_next_sample (void)
  * interrupt (which requires extremely careful programming).
  *
  */
-void end_of_sound (void)
+void end_of_sound (zword routine)
 {
 #if defined(DJGPP) && defined(SOUND_SUPPORT)
     end_of_sound_flag = 0;

--- a/src/curses/ux_audio.c
+++ b/src/curses/ux_audio.c
@@ -126,6 +126,7 @@ void os_init_sound(void)
     int err;
     static pthread_attr_t attr;
 
+    ao_initialize();
     pthread_mutex_init(&mutex, NULL);
     audiobuffer_init(&music_buffer);
     audiobuffer_init(&bleep_buffer);
@@ -135,7 +136,7 @@ void os_init_sound(void)
     pthread_attr_init(&attr);
     pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
-    err = pthread_create(&(mixer_id), &attr, (void *) &mixer, NULL);
+    err = pthread_create(&(mixer_id), &attr, &mixer, NULL);
     if (err != 0) {
 	printf("Can't create mixer thread :[%s]", strerror(err));
 	exit(1);
@@ -322,7 +323,6 @@ static void *mixer(void * UNUSED(arg))
     ao_sample_format format;
     int samplecount;
 
-    ao_initialize();
     default_driver = ao_default_driver_id();
 
     shortbuffer = malloc(BUFFSIZE * sizeof(short) * 2);

--- a/src/curses/ux_blorb.c
+++ b/src/curses/ux_blorb.c
@@ -81,8 +81,9 @@ bb_err_t ux_blorb_init(char *filename)
      */
     if (isblorb(fp)) {			/* Now we know to look */
 	f_setup.exec_in_blorb = 1;	/* for zcode in the blorb */
-        blorb_fp = fopen(filename, "rb");
+        blorb_fp = fp;
     } else {
+        fclose(fp);
 	len1 = strlen(filename) + strlen(EXT_BLORB);
 	len2 = strlen(filename) + strlen(EXT_BLORB3);
 
@@ -94,24 +95,23 @@ bb_err_t ux_blorb_init(char *filename)
 
         strncat(mystring, EXT_BLORB, len1 * sizeof(char));
 
-	/* Done monkeying with the initial file. */
-	fclose(fp);
-	fp = NULL;
-
 	/* Check if foo.blb is there. */
-        if ((blorb_fp = fopen(mystring, "rb")) == NULL) {
+        if ((fp = fopen(mystring, "rb")) == NULL) {
 	    p = rindex(mystring, '.');
 	    if (p != NULL)
 		*p = '\0';
             strncat(mystring, EXT_BLORB3, len2 * sizeof(char));
-	    blorb_fp = fopen(mystring, "rb");
+	    if (!(fp = fopen(mystring, "rb")))
+	        return bb_err_NoBlorb;
 	}
-
-	if (blorb_fp == NULL || !isblorb(fp))	/* No matching blorbs found. */
+	if (!isblorb(fp)) {
+	    fclose(fp);
 	    return bb_err_NoBlorb;
+	}
 
 	/* At this point we know that we're using a naked zcode file */
 	/* with resources in a seperate Blorb file. */
+	blorb_fp = fp;
 	f_setup.use_blorb = 1;
     }
 
@@ -119,7 +119,7 @@ bb_err_t ux_blorb_init(char *filename)
      * This will fail if the file is not a valid Blorb file.
      * From this map, we can now pick out any resource we need.
      */
-    blorb_err = bb_create_map(fp, &blorb_map);
+    blorb_err = bb_create_map(blorb_fp, &blorb_map);
     if (blorb_err != bb_err_None)
 	return bb_err_Format;
 
@@ -132,7 +132,6 @@ bb_err_t ux_blorb_init(char *filename)
 	f_setup.exec_in_blorb = 1;
     }
 
-    fclose(fp);
     return blorb_err;
 }
 

--- a/src/curses/ux_blorb.c
+++ b/src/curses/ux_blorb.c
@@ -89,7 +89,7 @@ bb_err_t ux_blorb_init(char *filename)
 
 	mystring = malloc(len2 * sizeof(char) + 1);
         strncpy(mystring, filename, len1 * sizeof(char));
-	p = rindex(mystring, '.');
+	p = strrchr(mystring, '.');
 	if (p != NULL)
 	    *p = '\0';
 
@@ -97,7 +97,7 @@ bb_err_t ux_blorb_init(char *filename)
 
 	/* Check if foo.blb is there. */
         if ((fp = fopen(mystring, "rb")) == NULL) {
-	    p = rindex(mystring, '.');
+	    p = strrchr(mystring, '.');
 	    if (p != NULL)
 		*p = '\0';
             strncat(mystring, EXT_BLORB3, len2 * sizeof(char));

--- a/src/curses/ux_frotz.h
+++ b/src/curses/ux_frotz.h
@@ -13,10 +13,6 @@
 #include "../blorb/blorblow.h"
 #include "ux_setup.h"
 
-#ifndef rindex
-    #define rindex strrchr
-#endif
-
 #define MASTER_CONFIG		"frotz.conf"
 #define USER_CONFIG		".frotzrc"
 #define ASCII_DEF		1

--- a/src/curses/ux_input.c
+++ b/src/curses/ux_input.c
@@ -133,6 +133,15 @@ static int timeout_to_ms()
 #endif
 
 
+void os_tick()
+{
+    while (terminal_resized) {
+        terminal_resized = 0;
+        unix_resize_display();
+    }
+}
+
+
 /*
  * unix_read_char
  *
@@ -155,10 +164,7 @@ static int unix_read_char(int extkeys)
         /* Wait with select so that we get interrupted on SIGWINCH. */
         FD_ZERO(&rsel);
         FD_SET(fd, &rsel);
-        while (terminal_resized) {
-            terminal_resized = 0;
-            unix_resize_display();
-        }
+        os_tick();
         refresh();
         t_left = timeout_left(&tval) ? &tval : NULL;
         sel = select(fd + 1, &rsel, NULL, NULL, t_left);

--- a/src/dumb/dumb_blorb.c
+++ b/src/dumb/dumb_blorb.c
@@ -79,7 +79,7 @@ bb_err_t dumb_blorb_init(char *filename)
 
 	mystring = malloc(len2 * sizeof(char) + 1);
         strncpy(mystring, filename, len1 * sizeof(char));
-	p = rindex(mystring, '.');
+	p = strrchr(mystring, '.');
 	if (p != NULL)
 	    *p = '\0';
 
@@ -91,7 +91,7 @@ bb_err_t dumb_blorb_init(char *filename)
 
 	/* Check if foo.blb is there. */
         if ((blorb_fp = fopen(mystring, "rb")) == NULL) {
-	    p = rindex(mystring, '.');
+	    p = strrchr(mystring, '.');
 	    if (p != NULL)
 		*p = '\0';
             strncat(mystring, EXT_BLORB3, len2 * sizeof(char));

--- a/src/dumb/dumb_blorb.h
+++ b/src/dumb/dumb_blorb.h
@@ -21,7 +21,7 @@ typedef struct sampledata_struct {
  */
 typedef struct {
     bb_result_t bbres;
-    ulong type;
+    unsigned long type;
     FILE *fp;
 } myresource;
 

--- a/src/dumb/dumb_input.c
+++ b/src/dumb/dumb_input.c
@@ -21,6 +21,8 @@
 
 #include "dumb_frotz.h"
 
+#include <string.h>
+
 f_setup_t f_setup;
 
 static char runtime_usage[] =

--- a/src/dumb/dumb_input.c
+++ b/src/dumb/dumb_input.c
@@ -19,9 +19,9 @@
  * Or visit http://www.fsf.org/
  */
 
-#include "dumb_frotz.h"
-
 #include <string.h>
+
+#include "dumb_frotz.h"
 
 f_setup_t f_setup;
 
@@ -476,3 +476,6 @@ zword os_read_mouse(void)
 	/* NOT IMPLEMENTED */
     return 0;
 }
+
+void os_tick()
+{}

--- a/src/sdl/Makefile
+++ b/src/sdl/Makefile
@@ -7,7 +7,7 @@ ARFLAGS = rvU
 
 SOURCES = sf_aiffwav.c sf_fonts.c sf_msg_en.c sf_resource.c sf_util.c \
 	sf_deffont.c sf_ftype.c sf_osfdlg.c sf_sig.c sf_video.c \
-	sf_font3.c sf_images.c sf_resample.c sf_sound.c generic.c
+	sf_font3.c sf_images.c sf_sound.c generic.c
 
 HEADERS = samplerate.h  sf_frotz.h
 

--- a/src/sdl/Makefile
+++ b/src/sdl/Makefile
@@ -1,0 +1,36 @@
+# For GNU Make.
+
+PKGS = sdl SDL_mixer freetype2
+
+CC = gcc
+CFLAGS += `pkg-config $(PKGS) --cflags`
+ARFLAGS = rvU
+
+SOURCES = sf_aiffwav.c sf_fonts.c sf_msg_en.c sf_resource.c sf_util.c \
+	sf_deffont.c sf_ftype.c sf_osfdlg.c sf_sig.c sf_video.c \
+	sf_font3.c sf_images.c sf_resample.c sf_sound.c
+
+HEADERS = samplerate.h  sf_frotz.h
+
+OBJECTS = $(SOURCES:.c=.o)
+
+DEPS = $(SOURCES:.c=.d)
+
+TARGET = frotz_sdl.a
+
+.PHONY: clean distclean
+.DELETE_ON_ERROR:
+
+$(TARGET): $(TARGET)($(OBJECTS))
+	ranlib $@
+
+clean:
+	-rm -f $(TARGET) $(OBJECTS)
+
+distclean: clean
+	-rm -f $(DEPS)
+
+%.d: %.c
+	gcc -MM $(CFLAGS) $< > $@
+
+include $(DEPS)

--- a/src/sdl/Makefile
+++ b/src/sdl/Makefile
@@ -2,13 +2,12 @@
 
 SDL_PKGS ?= libpng libjpeg libsdl SDL_mixer freetype2 zlib
 
-CC = gcc
 CFLAGS += `pkg-config $(SDL_PKGS) --cflags`
 ARFLAGS = rvU
 
 SOURCES = sf_aiffwav.c sf_fonts.c sf_msg_en.c sf_resource.c sf_util.c \
 	sf_deffont.c sf_ftype.c sf_osfdlg.c sf_sig.c sf_video.c \
-	sf_font3.c sf_images.c sf_resample.c sf_sound.c
+	sf_font3.c sf_images.c sf_resample.c sf_sound.c generic.c
 
 HEADERS = samplerate.h  sf_frotz.h
 

--- a/src/sdl/Makefile
+++ b/src/sdl/Makefile
@@ -5,7 +5,7 @@ SDL_PKGS ?= libpng libjpeg libsdl SDL_mixer freetype2 zlib
 CFLAGS += `pkg-config $(SDL_PKGS) --cflags`
 ARFLAGS = rvU
 
-SOURCES = sf_aiffwav.c sf_fonts.c sf_msg_en.c sf_resource.c sf_util.c \
+SOURCES = sf_fonts.c sf_msg_en.c sf_resource.c sf_util.c \
 	sf_deffont.c sf_ftype.c sf_osfdlg.c sf_sig.c sf_video.c \
 	sf_font3.c sf_images.c sf_sound.c generic.c
 

--- a/src/sdl/Makefile
+++ b/src/sdl/Makefile
@@ -3,7 +3,6 @@
 SDL_PKGS ?= libpng libjpeg libsdl SDL_mixer freetype2 zlib
 
 CFLAGS += `pkg-config $(SDL_PKGS) --cflags`
-ARFLAGS = rvU
 
 SOURCES = sf_fonts.c sf_msg_en.c sf_resource.c sf_util.c \
 	sf_deffont.c sf_ftype.c sf_osfdlg.c sf_sig.c sf_video.c \
@@ -20,7 +19,8 @@ TARGET = frotz_sdl.a
 .PHONY: clean distclean
 .DELETE_ON_ERROR:
 
-$(TARGET): $(TARGET)($(OBJECTS))
+$(TARGET): $(OBJECTS)
+	$(AR) $(ARFLAGS) $@ $?
 	ranlib $@
 
 clean:

--- a/src/sdl/Makefile
+++ b/src/sdl/Makefile
@@ -1,9 +1,9 @@
 # For GNU Make.
 
-PKGS = sdl SDL_mixer freetype2
+SDL_PKGS ?= libpng libjpeg libsdl SDL_mixer freetype2 zlib
 
 CC = gcc
-CFLAGS += `pkg-config $(PKGS) --cflags`
+CFLAGS += `pkg-config $(SDL_PKGS) --cflags`
 ARFLAGS = rvU
 
 SOURCES = sf_aiffwav.c sf_fonts.c sf_msg_en.c sf_resource.c sf_util.c \

--- a/src/sdl/generic.c
+++ b/src/sdl/generic.c
@@ -248,9 +248,11 @@ void os_warn (const char *s, ...)
     os_set_text_style(BOLDFACE_STYLE);
     os_display_string((zchar *)"Warning: ");
     os_set_text_style(0);
-    os_display_string((zchar *)buf);
+    os_display_string((zchar *)(len < 0 ? s : buf));
     os_display_string((zchar *)"\n");
-    if (len > sizeof(buf))
+    if (len < 0)
+        os_display_string((zchar *)"(formatting error)\n");
+    else if (len >= sizeof(buf))
         os_display_string((zchar *)"(truncated)\n");
     new_line();
 }
@@ -275,8 +277,7 @@ void gen_add_to_history(zchar *str)
 
     if (*history_next != NULL)
         free( *history_next);
-    *history_next = (char *)malloc(strlen((char *)str) + 1);
-    strcpy( *history_next, (char *)str);
+    *history_next = strdup((char *)str);
     RING_INC( history_next, history_buffer, history_end);
     history_view = history_next; /* Reset user frame after each line */
 

--- a/src/sdl/generic.c
+++ b/src/sdl/generic.c
@@ -1,0 +1,255 @@
+/**
+ * @file generic.c
+ *
+ * The functions here are identical or nearly so in most ports.  They should
+ * really be put somewhere so that they can be shared.  For now, this.
+ */
+
+#include <stddef.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../blorb/blorb.h"
+#include "../common/frotz.h"
+
+FILE *blorb_fp;
+bb_result_t blorb_res;
+bb_map_t *blorb_map;
+
+/*
+ * isblorb
+ *
+ * Returns 1 if this file is a Blorb file, 0 if not.
+ */
+static int isblorb(FILE *fp)
+{
+    char mybuf[4];
+
+    if (fp == NULL)
+        return 0;
+
+    fread(mybuf, 1, 4, fp);
+    if (strncmp(mybuf, "FORM", 4))
+        return 0;
+
+    fseek(fp, 4, SEEK_CUR);
+    fread(mybuf, 1, 4, fp);
+
+    if (strncmp(mybuf, "IFRS", 4))
+        return 0;
+
+    return 1;
+}
+
+
+/*
+ * gen_blorb_init
+ *
+ * Check if we're opening a Blorb file directly.  If not, check
+ * to see if there's a seperate Blorb file that looks like it goes
+ * along with this Zcode file.  If we have a Blorb file one way or the
+ * other, make a Blorb map.  If we opened a Blorb file directly, that
+ * means that our executable is in that file and therefore we will look
+ * for a ZCOD chunk and record its location so os_load_story() can find it.
+ * Make sure the Blorb file is opened and with the file pointer blorb_fp.
+ */
+bb_err_t gen_blorb_init(char *filename)
+{
+    FILE *fp;
+    char *p;
+    char *mystring;
+    int  len1;
+    int  len2;
+
+    bb_err_t blorb_err;
+
+    blorb_map = NULL;
+
+    if ((fp = fopen(filename, "rb")) == NULL)
+        return bb_err_Read;
+
+    /* Is this really a Blorb file?  If not, maybe we're loading a naked
+     * zcode file and our resources are in a seperate blorb file.
+     */
+    if (isblorb(fp)) {                  /* Now we know to look */
+        f_setup.exec_in_blorb = 1;      /* for zcode in the blorb */
+        blorb_fp = fp;
+    } else {
+        fclose(fp);
+        len1 = strlen(filename) + strlen(EXT_BLORB);
+        len2 = strlen(filename) + strlen(EXT_BLORB3);
+
+        mystring = malloc(len2 * sizeof(char) + 1);
+        strncpy(mystring, filename, len1 * sizeof(char));
+        p = strrchr(mystring, '.');
+        if (p != NULL)
+            *p = '\0';
+
+        strncat(mystring, EXT_BLORB, len1 * sizeof(char));
+
+        /* Check if foo.blb is there. */
+        if ((fp = fopen(mystring, "rb")) == NULL) {
+            p = strrchr(mystring, '.');
+            if (p != NULL)
+                *p = '\0';
+            strncat(mystring, EXT_BLORB3, len2 * sizeof(char));
+            if (!(fp = fopen(mystring, "rb")))
+                return bb_err_NoBlorb;
+        }
+        if (!isblorb(fp)) {
+            fclose(fp);
+            return bb_err_NoBlorb;
+        }
+
+        /* At this point we know that we're using a naked zcode file */
+        /* with resources in a seperate Blorb file. */
+        blorb_fp = fp;
+        f_setup.use_blorb = 1;
+    }
+
+    /* Create a Blorb map from this file.
+     * This will fail if the file is not a valid Blorb file.
+     * From this map, we can now pick out any resource we need.
+     */
+    blorb_err = bb_create_map(blorb_fp, &blorb_map);
+    if (blorb_err != bb_err_None)
+        return bb_err_Format;
+
+    /* Locate the EXEC chunk within the blorb file and record its
+     * location so os_load_story() can find it.
+     */
+    if (f_setup.exec_in_blorb) {
+        blorb_err = bb_load_chunk_by_type(blorb_map, bb_method_FilePos,
+                &blorb_res, bb_make_id('Z','C','O','D'), 0);
+        f_setup.exec_in_blorb = 1;
+    }
+
+    return blorb_err;
+}
+
+/*
+ * os_load_story
+ *
+ * This is different from os_path_open() because we need to see if the
+ * story file is actually a chunk inside a blorb file.  Right now we're
+ * looking only at the exact path we're given on the command line.
+ *
+ * Open a file in the current directory.  If this fails, then search the
+ * directories in the ZCODE_PATH environmental variable.  If that's not
+ * defined, search INFOCOM_PATH.
+ *
+ */
+FILE *os_load_story(void)
+{
+    FILE *fp;
+
+    switch (gen_blorb_init(f_setup.story_file)) {
+        case bb_err_NoBlorb:
+//        printf("No blorb file found.\n\n");
+          break;
+        case bb_err_Format:
+          printf("Blorb file loaded, but unable to build map.\n\n");
+          break;
+        case bb_err_NotFound:
+          printf("Blorb file loaded, but lacks executable chunk.\n\n");
+          break;
+        case bb_err_None:
+//        printf("No blorb errors.\n\n");
+          break;
+    }
+
+    fp = fopen(f_setup.story_file, "rb");
+
+    /* Is this a Blorb file containing Zcode? */
+    if (f_setup.exec_in_blorb)
+        fseek(fp, blorb_res.data.startpos, SEEK_SET);
+
+    return fp;
+}
+
+
+/*
+ * os_storyfile_seek
+ *
+ * Seek into a storyfile, either a standalone file or the
+ * ZCODE chunk of a blorb file.
+ *
+ */
+int os_storyfile_seek(FILE * fp, long offset, int whence)
+{
+    /* Is this a Blorb file containing Zcode? */
+    if (f_setup.exec_in_blorb)
+    {
+        switch (whence)
+        {
+            case SEEK_END:
+                return fseek(fp, blorb_res.data.startpos + blorb_res.length + offset, SEEK_SET);
+                break;
+            case SEEK_CUR:
+                return fseek(fp, offset, SEEK_CUR);
+                break;
+            case SEEK_SET:
+            default:
+                return fseek(fp, blorb_res.data.startpos + offset, SEEK_SET);
+                break;
+        }
+    }
+    else
+    {
+        return fseek(fp, offset, whence);
+    }
+
+}
+
+
+/*
+ * os_storyfile_tell
+ *
+ * Tell the position in a storyfile, either a standalone file
+ * or the ZCODE chunk of a blorb file.
+ *
+ */
+int os_storyfile_tell(FILE * fp)
+{
+    /* Is this a Blorb file containing Zcode? */
+    if (f_setup.exec_in_blorb)
+    {
+        return ftell(fp) - blorb_res.data.startpos;
+    }
+    else
+    {
+        return ftell(fp);
+    }
+
+}
+
+/*
+ * os_warn
+ *
+ * Display a warning message and continue with the game.
+ *
+ */
+void os_warn (const char *s, ...)
+{
+    va_list va;
+    char buf[1024];
+    int len;
+
+    //XXX Too lazy to do this right (try again with a bigger buf if necessary).
+    va_start(va, s);
+    len = vsnprintf(buf, sizeof(buf), s, va);
+    va_end(va);
+    /* Solaris 2.6's cc complains if the below cast is missing */
+    os_display_string((zchar *)"\n\n");
+    os_beep(BEEP_HIGH);
+    os_set_text_style(BOLDFACE_STYLE);
+    os_display_string((zchar *)"Warning: ");
+    os_set_text_style(0);
+    os_display_string((zchar *)buf);
+    os_display_string((zchar *)"\n");
+    if (len > sizeof(buf))
+        os_display_string((zchar *)"(truncated)\n");
+    new_line();
+}/* os_warn */

--- a/src/sdl/generic.h
+++ b/src/sdl/generic.h
@@ -1,0 +1,17 @@
+/**
+ * @file generic.h
+ *
+ * Generic useful user interface utility functions.
+ */
+
+#ifndef FROTZ_GENERIC_H_
+#define FROTZ_GENERIC_H_
+
+#include "../common/frotz.h"
+
+void gen_add_to_history(zchar *buf);
+void gen_history_reset(void);
+int gen_history_back(zchar *str, int searchlen, int maxlen);
+int gen_history_forward(zchar *str, int searchlen, int maxlen);
+
+#endif

--- a/src/sdl/sf_aiffwav.c
+++ b/src/sdl/sf_aiffwav.c
@@ -4,6 +4,8 @@
 // as libmikmod only reads WAV samples
 //
 
+//XXX Dead code, whole file.
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/sdl/sf_font3.c
+++ b/src/sdl/sf_font3.c
@@ -113,7 +113,9 @@ static int mydescent(SFONT *s){ return 2;}
 static int myminchar(SFONT *s){ return 32;}
 static int mymaxchar(SFONT *s){ return 126;}
 static int myhasglyph(SFONT *s, word c, int allowdef)
-  { if (c >= 32 && c <= 126) return 1; if (allowdef) return 1;}
+{
+    return (c >= 32 && c <= 126) || allowdef;
+}
 static SF_glyph * mygetglyph(SFONT *s, word c, int allowdef)
   {
   byte *src;

--- a/src/sdl/sf_font3.c
+++ b/src/sdl/sf_font3.c
@@ -104,7 +104,7 @@ static struct {
   byte w, h;
   char xof, yof;
   byte bitmap[16];
-  } myglyph = {8,8,8,0,0};
+  } myglyph = {8,8,8,0,-2};
 
 static void nodestroy(SFONT *s){}
 static int myheight(SFONT *s){ return 8;}
@@ -144,8 +144,8 @@ static SFONT myfont3 = {
 SFONT * SF_font3 = &myfont3;
 
 static int myheight2(SFONT *s){ return 16;}
-static int myascent2(SFONT *s){ return 12;}
-static int mydescent2(SFONT *s){ return 4;}
+static int myascent2(SFONT *s){ return 14;}
+static int mydescent2(SFONT *s){ return 2;}
 static SF_glyph * mygetglyph2(SFONT *s, word c, int allowdef)
   {
   byte *src, *dst; int i;

--- a/src/sdl/sf_fonts.c
+++ b/src/sdl/sf_fonts.c
@@ -740,9 +740,8 @@ SFONT *sf_VGA_SFONT;
 void sf_initfonts()
   {
   int i, j, size=0;
-  int w,h,nby,m,nocc;
   byte *cfont, *bmp; SF_glyph *g;
-  SF_bdffont *b, *norm, *emph, *bold, *bemp;
+  SF_bdffont *norm, *emph, *bold, *bemp;
   SFONT *Norm, *Emph=NULL, *Bold=NULL, *Bemp=NULL;
 
   norm = SF_defaultfont;
@@ -763,13 +762,11 @@ void sf_initfonts()
 	// emphasize (underline)...
   cfont = (byte *)emph;
   for (i = norm->minchar;i <= norm->maxchar;i++){
-	m = norm->glyphs[i-norm->minchar];
+	int m = norm->glyphs[i-norm->minchar];
 	if (!m) continue;
 	g = (SF_glyph *)(cfont + m);
-	w = g->dx;
-	h = g->h; nby = (g->w+7)/8;
 	bmp = (byte *)(&(g->bitmap[0]));
-	bmp[h-2] = 0xff;
+	bmp[g->h - 2] = 0xff;
 	}
 	// make a copy for bold
   bold = malloc(size);
@@ -780,15 +777,13 @@ void sf_initfonts()
 	// boldify...
   cfont = (byte *)bold;
   for (i = norm->minchar;i <= norm->maxchar;i++){
-	int c;
-	m = norm->glyphs[i-norm->minchar];
+	int h, m = norm->glyphs[i-norm->minchar];
 	if (!m) continue;
 	g = (SF_glyph *)(cfont + m);
-	w = g->dx;
-	h = g->h; nby = (g->w+7)/8;
+	h = g->h;
 	bmp = (byte *)(&(g->bitmap[0]));
 	for (j=0;j<h;j++){
-	  c = bmp[j];
+	  int c = bmp[j];
 	  bmp[j] = (c) | (c >> 1);
 	  }
 	}
@@ -801,13 +796,11 @@ void sf_initfonts()
 	// emphasize (underline)...
   cfont = (byte *)bemp;
   for (i = norm->minchar;i <= norm->maxchar;i++){
-	m = norm->glyphs[i-norm->minchar];
+	int m = norm->glyphs[i-norm->minchar];
 	if (!m) continue;
 	g = (SF_glyph *)(cfont + m);
-	w = g->dx;
-	h = g->h; nby = (g->w+7)/8;
 	bmp = (byte *)(&(g->bitmap[0]));
-	bmp[h-2] = 0xff;
+	bmp[g->h - 2] = 0xff;
 	}
 
   myfonts[0] = myfonts[4] = Norm;
@@ -842,11 +835,12 @@ void sf_initfonts()
 
   if (ttfontsdone) ttfontsdone();
 	// now set the graphics font
-  if (!myfonts[8])
+  if (!myfonts[8]) {
       if (myfonts[4]->height(myfonts[4]) < 16)
           myfonts[8] = SF_font3;
       else
           myfonts[8] = SF_font3double;
+  }
 
 //for (i=0;i<8;i++){ SFONT *s = myfonts[i]; printf("%d %p %d %d %d %d %d\n",
 //i,s,s->minchar(s),s->maxchar(s),s->ascent(s),s->descent(s),s->height(s));}

--- a/src/sdl/sf_fonts.c
+++ b/src/sdl/sf_fonts.c
@@ -27,7 +27,7 @@ typedef struct {
   int glyphs[0];        // offsets to glyphs from start of rec
   } SF_bdffont;
 
-char * m_fontfiles[8];
+char * m_fontfiles[9];
 
 static char s[1026];
 
@@ -710,10 +710,10 @@ static void destroySFonly( SFONT *f)
 
 extern SFONT *SF_font3, *SF_font3double;
 
-SFONT * (*ttfontloader)( char *fspec, int *err) = NULL;
+SFONT * (*ttfontloader)( char *fspec, SFONT *like, int *err) = NULL;
 void (*ttfontsdone)() = NULL;
 
-static SFONT *tryloadfont( char *fspec)
+static SFONT *tryloadfont( char *fspec, SFONT *like)
   {
   int err,size;
   char *p;
@@ -722,7 +722,7 @@ static SFONT *tryloadfont( char *fspec)
     p = strchr(fspec,'|');
     if (p) *p = 0;
     if (ttfontloader)
-	b = ttfontloader(fspec,&err);
+	b = ttfontloader(fspec, like, &err);
     if (!b)
 	b = loadfont(fspec,&err,&size);
     if (b) break;
@@ -824,10 +824,11 @@ void sf_initfonts()
 
   if (!m_vga_fonts)
     {
-    for (i=0;i<8;i++)
+    for (i = 0; i <= 8; i++)
       if (m_fontfiles[i])
 	{
-	SFONT *b = tryloadfont(m_fontfiles[i]);
+	SFONT *b = tryloadfont(m_fontfiles[i],
+	                       i == 8 ? myfonts[FIXED_WIDTH_FONT] : NULL);
 	if (!b) fprintf(stderr,"WARNING: could not load font%d [%s]\n",i,m_fontfiles[i]);
 	else
 		{
@@ -839,10 +840,11 @@ void sf_initfonts()
 
   if (ttfontsdone) ttfontsdone();
 	// now set the graphics font
-  if (myfonts[4]->height(myfonts[4]) < 16)
-	myfonts[8] = SF_font3;
-  else
-	myfonts[8] = SF_font3double;
+  if (!myfonts[8])
+      if (myfonts[4]->height(myfonts[4]) < 16)
+          myfonts[8] = SF_font3;
+      else
+          myfonts[8] = SF_font3double;
 
 //for (i=0;i<8;i++){ SFONT *s = myfonts[i]; printf("%d %p %d %d %d %d %d\n",
 //i,s,s->minchar(s),s->maxchar(s),s->ascent(s),s->descent(s),s->height(s));}

--- a/src/sdl/sf_fonts.c
+++ b/src/sdl/sf_fonts.c
@@ -572,12 +572,12 @@ int os_string_width(const zchar *s)
 	{
 	if (c == ZC_NEW_STYLE)
 		{
-		wacc = width+oh; width = 0;
+		wacc += oh;
 		os_set_text_style(*s++);
 		}
 	else if (c == ZC_NEW_FONT)
 		{
-		wacc = width+oh; width = 0;
+		wacc += oh;
 		os_set_font(*s++);
 		}
 	else

--- a/src/sdl/sf_fonts.c
+++ b/src/sdl/sf_fonts.c
@@ -498,27 +498,29 @@ static void setstyle( int style){
  * the given font is unavailable then these values must _not_
  * be changed.
  *
+ * Font can also be 0 to query the size of the current font in the current
+ * style.  Not all front end support this.  Those that do return true.
  */
-int os_font_data( int font, int *height, int *width)
-  {
-  switch (font)
-	{
-	case TEXT_FONT:
-	case FIXED_WIDTH_FONT:
-	case GRAPHICS_FONT:
-		{
-		sf_pushtextsettings();
-		setfont(font);
-		setstyle(0);
-		*height = current.font->height(current.font);
-		*width = os_char_width((zword)('0'));
-		sf_poptextsettings();
-		return 1;
-		}
-	default: break;
-	}
-  return 0;
-  }
+int os_font_data( int font, int *height, int *width) {
+    switch (font) {
+    case TEXT_FONT:
+    case FIXED_WIDTH_FONT:
+    case GRAPHICS_FONT:
+        sf_pushtextsettings();
+        setfont(font);
+        setstyle(0);
+        *height = current.font->height(current.font);
+        *width = os_char_width((zword)('0'));
+        sf_poptextsettings();
+        return 1;
+    case 0:
+        *height = current.font->height(current.font);
+        *width = os_char_width((zword)('0'));
+        return 1;
+    default:
+        return 0;
+    }
+}
 
 /*
  * os_set_font

--- a/src/sdl/sf_frotz.h
+++ b/src/sdl/sf_frotz.h
@@ -181,6 +181,9 @@ int sf_initsound(void);
 
 void sf_initfonts(void);
 
+void sf_setdialog(void);
+void sf_initloader(void);
+
 void sf_cleanup_all(void);
 void sf_regcleanfunc( void *f, const char *nam);
 #define CLEANREG( f) sf_regcleanfunc( (void *)f, #f)

--- a/src/sdl/sf_frotz.h
+++ b/src/sdl/sf_frotz.h
@@ -86,7 +86,7 @@ extern int	AcHeight;
 extern int	m_random_seed;
 extern int	m_fullscreen;
 extern int	m_reqW, m_reqH;
-extern char *	m_fontfiles[8];
+extern char *	m_fontfiles[9];
 extern bool	m_localfiles;
 extern int	m_no_sound;
 extern int 	m_vga_fonts;
@@ -131,7 +131,7 @@ typedef struct {
 
 typedef struct sfontstruct SFONT;
 
-extern SFONT * (*ttfontloader)( char *fspec, int *err);
+extern SFONT * (*ttfontloader)( char *fspec, SFONT *like, int *err);
 extern void    (*ttfontsdone)();
 
 struct sfontstruct {

--- a/src/sdl/sf_frotz.h
+++ b/src/sdl/sf_frotz.h
@@ -249,6 +249,8 @@ void sf_FinishProfile(void);
 // virtual keys
 #define VK_TAB	0x16
 #define VK_INS	0x17
+#define VK_PAGE_UP 0x18
+#define VK_PAGE_DOWN 0x19
 
 // for AIFF resampling
 

--- a/src/sdl/sf_frotz.h
+++ b/src/sdl/sf_frotz.h
@@ -158,7 +158,7 @@ typedef struct {
   bool foreDefault, backDefault, backTransparent;
   } SF_textsetting;
 
-SF_textsetting * sf_curtextsetting();
+SF_textsetting * sf_curtextsetting(void);
 
 void sf_writeglyph( SF_glyph *g);
 
@@ -177,9 +177,11 @@ int sf_GetColourIndex( ulong colour);
 
 void sf_initvideo( int w, int h, int full);
 
-int sf_initsound();
+int sf_initsound(void);
 
-void sf_cleanup_all();
+void sf_initfonts(void);
+
+void sf_cleanup_all(void);
 void sf_regcleanfunc( void *f, const char *nam);
 #define CLEANREG( f) sf_regcleanfunc( (void *)f, #f)
 
@@ -193,7 +195,7 @@ enum { IDS_BLORB_GLULX, IDS_BLORB_NOEXEC, IDS_MORE, IDS_HIT_KEY_EXIT, IDS_TITLE,
  IDS_RECORD_FILTER, IDS_RECORD_TITLE, IDS_PLAYBACK_TITLE,
  IDS_AUX_FILTER, IDS_SAVE_AUX_TITLE, IDS_LOAD_AUX_TITLE };
 
-bool sf_IsInfocomV6();
+bool sf_IsInfocomV6(void);
 
 ulong sf_blend( int a, ulong s, ulong d);
 
@@ -216,6 +218,24 @@ zword sf_read_key( int timeout, int cursor, int allowed);
 int sf_user_fdialog( bool exist, const char *def, const char *filt, const char *title, char **res);
 extern int (*sf_osdialog)( bool ex, const char *def, const char *filt, const char *tit, char **res,
 	ulong *sbuf, int sbp, int ew, int eh, int isfull);
+
+void sf_checksound(void);
+
+void sf_installhandlers(void);
+
+void sf_pushtextsettings(void);
+void sf_poptextsettings(void);
+
+void sf_chline( int x, int y, ulong c, int n);
+void sf_cvline( int x, int y, ulong c, int n);
+void sf_flushdisplay(void);
+void sf_getclip( int *x, int *y, int *w, int *h);
+void sf_rect( unsigned long color, int x, int y, int w, int h);
+void sf_setclip( int x, int y, int w, int h);
+void sf_wpixel( int x, int y, ulong c);
+
+void sf_InitProfile( const char *fn);
+void sf_FinishProfile(void);
 
 #ifdef WIN32
 #define OS_PATHSEP ';'

--- a/src/sdl/sf_ftype.c
+++ b/src/sdl/sf_ftype.c
@@ -197,7 +197,7 @@ static void setglyph( MYFONT *f, FT_Face face, int ch)
   res->h = bitmap->rows;
   res->dx = slot->advance.x/64;
   res->xof = slot->bitmap_left;
-  res->yof = slot->bitmap_top - bitmap->rows;
+  res->yof = slot->bitmap_top - bitmap->rows + 1;
 
   f->glyphs[ch] = res;
   }
@@ -228,7 +228,7 @@ static SFONT * loadftype( char *fname, int size, SFONT *like, int *err)
 
   res->ascent = face->size->metrics.ascender/64;
   res->descent = -face->size->metrics.descender/64;
-  res->height = res->ascent+res->descent; //face->size->metrics.height/64;
+  res->height = face->size->metrics.height/64;
 
   res->sfont.antialiased = m_aafonts;
   res->minchar = 32;

--- a/src/sdl/sf_ftype.c
+++ b/src/sdl/sf_ftype.c
@@ -96,7 +96,7 @@ static SF_glyph *getglyph( SFONT *s, word c, int allowdef)
   {
   if (s)
     {
-    int i; MYFONT *f = (MYFONT *)s;
+    MYFONT *f = (MYFONT *)s;
     if (c < f->minchar || c > f->maxchar)
 	{
 	if (allowdef) c = 0;
@@ -164,8 +164,7 @@ static void setglyph( MYFONT *f, FT_Face face, int ch)
   int mode = FT_RENDER_MODE_MONO;
   SF_glyph *res;
   FT_GlyphSlot slot = face->glyph;
-  int i,j, nbypr, pitch;
-  unsigned char *s;
+  int i,j, nbypr;
   FT_Bitmap *bitmap;
 
   if (m_aafonts) mode = FT_RENDER_MODE_NORMAL;

--- a/src/sdl/sf_ftype.c
+++ b/src/sdl/sf_ftype.c
@@ -202,7 +202,7 @@ static void setglyph( MYFONT *f, FT_Face face, int ch)
   f->glyphs[ch] = res;
   }
 
-static SFONT * loadftype( char *fname, int size, int *err)
+static SFONT * loadftype( char *fname, int size, SFONT *like, int *err)
   {
   MYFONT *res;
   FT_Face face;
@@ -219,7 +219,11 @@ static SFONT * loadftype( char *fname, int size, int *err)
   *err = FT_New_Face( library, fname, 0, &face ); /* create face object */
   if (*err){ res->sfont.destroy(&res->sfont); return NULL; }
 
-  *err = FT_Set_Pixel_Sizes( face, size, size);
+  if (like) {
+      SF_glyph *zero = like->getglyph(like, '0', TRUE);
+      *err = FT_Set_Pixel_Sizes( face, zero->dx, like->height(like));
+  } else
+      *err = FT_Set_Pixel_Sizes( face, size, size);
   if (*err){ res->sfont.destroy(&res->sfont); return NULL; }
 
   res->ascent = face->size->metrics.ascender/64;
@@ -247,7 +251,7 @@ static SFONT * loadftype( char *fname, int size, int *err)
 #define SYSFONTS "/usr/share/fonts/freetype"
 #endif
 
-SFONT * sf_loadftype( char *fspec, int *err)
+SFONT * sf_loadftype( char *fspec, SFONT *like, int *err)
   {
   char buf[FILENAME_MAX], *fn, *at, *fenv;
   int size = DEFSIZE, fnlen=-1;
@@ -273,7 +277,7 @@ SFONT * sf_loadftype( char *fspec, int *err)
 
   if (!fn) return NULL;
 
-  return loadftype(fn,size,err);
+  return loadftype(fn, size, like, err);
   }
 
 //////////////////////////////////////////

--- a/src/sdl/sf_ftype.c
+++ b/src/sdl/sf_ftype.c
@@ -278,10 +278,8 @@ SFONT * sf_loadftype( char *fspec, int *err)
 
 //////////////////////////////////////////
 
-static void initloader() __attribute__((constructor));
-static void initloader()
-  {
+void sf_initloader()
+{
   ttfontloader = sf_loadftype;
   ttfontsdone = libfinish;
-  }
-
+}

--- a/src/sdl/sf_images.c
+++ b/src/sdl/sf_images.c
@@ -94,7 +94,7 @@ static int loadpng( byte *data, int length, sf_picture *graphic)
 	return 0;
 	}
 
-  if (setjmp(png_ptr->jmpbuf))
+  if (setjmp(png_jmpbuf(png_ptr)))
 	{
 	png_destroy_read_struct(&png_ptr,&info_ptr,&end_info);
 	if (rowPointers) free(rowPointers);

--- a/src/sdl/sf_images.c
+++ b/src/sdl/sf_images.c
@@ -124,11 +124,7 @@ static int loadpng( byte *data, int length, sf_picture *graphic)
   if (color_type == PNG_COLOR_TYPE_PALETTE && bit_depth <= 8)
 	png_set_palette_to_rgb(png_ptr);
   if (color_type == PNG_COLOR_TYPE_GRAY && bit_depth < 8)
-  #ifdef __WIN32__
-    os_fatal("Missing png_set_gray_1_2_4_to_8\n");
-  #else
-	png_set_gray_1_2_4_to_8(png_ptr);
-  #endif
+  	png_set_expand_gray_1_2_4_to_8(png_ptr);
   if (png_get_valid(png_ptr,info_ptr,PNG_INFO_tRNS))
 	png_set_tRNS_to_alpha(png_ptr);
 

--- a/src/sdl/sf_msg_en.c
+++ b/src/sdl/sf_msg_en.c
@@ -56,7 +56,7 @@ const char * sf_msgstring( int id)
 	p = "*|Any file";
 	break;
     case IDS_SAVE_FILTER:
-	p = "*.sav|Saved games";
+	p = "*" EXT_SAVE "|Saved games";
 	break;
     case IDS_RECORD_TITLE:
 	p = "Record input to a file";
@@ -65,13 +65,13 @@ const char * sf_msgstring( int id)
 	p = "Play back recorded input";
 	break;
     case IDS_RECORD_FILTER:
-	p = "*.rec|Record Files";
+	p = "*" EXT_COMMAND "|Record Files";
 	break;
     case IDS_SCRIPT_TITLE:
 	p = "Write out a script";
 	break;
     case IDS_SCRIPT_FILTER:
-	p = "*.log|Transcript Log Files";
+	p = "*" EXT_SCRIPT "|Transcript Log Files";
 	break;
     default:
 	break;

--- a/src/sdl/sf_osfdlg.c
+++ b/src/sdl/sf_osfdlg.c
@@ -390,11 +390,10 @@ STATIC int myosdialog( bool existing, const char *def, const char *filt, const c
   return SF_NOTIMP;
   }
 
-static void setdialog(void) __attribute__((constructor));
-static void setdialog(void)
-  {
+void sf_setdialog(void)
+{
   sf_osdialog = myosdialog;
-  }
+}
 
 ///////////////////////////////////
 

--- a/src/sdl/sf_osfdlg.c
+++ b/src/sdl/sf_osfdlg.c
@@ -653,7 +653,7 @@ static unsigned char docbmp[] = {
 
 STATIC void drawit( int x, int y, ENTRY *e, int w, int issub)
   {
-  int i,j,n,sw,dy,color;
+  int i, j, n, color;
   unsigned char *bmp;
   char *s = e->value;
   bmp = (issub ? folderbmp : docbmp);
@@ -841,7 +841,7 @@ STATIC zword yesnoover( int xc, int yc)
 // (lib does not guarantee correct behaviour in that case)
 static void mystrcpy( char *d, const char *s)
   {
-  while (*d++ = *s++);
+  while ((*d++ = *s++));
   }
 
 STATIC zword Zentry( int x, int y)

--- a/src/sdl/sf_resample.c
+++ b/src/sdl/sf_resample.c
@@ -8,6 +8,8 @@
 
 #include "samplerate.h"
 
+//XXX Dead code, whole file.
+
 static int myconv( CONV *conv, FILE *f, void *dest, int nin, int eod)
   {
   int nbrd, i, j, v=0;

--- a/src/sdl/sf_resource.c
+++ b/src/sdl/sf_resource.c
@@ -1030,7 +1030,6 @@ void os_init_setup(void)
 	f_setup.undo_slots = MAX_UNDO_SLOTS;
 	f_setup.expand_abbreviations = 0;
 	f_setup.script_cols = 80;
-	f_setup.save_quetzal = 1;
 	f_setup.sound = 1;
 	f_setup.err_report_mode = ERR_DEFAULT_REPORT_MODE;
 	f_setup.restore_mode = 0;

--- a/src/sdl/sf_resource.c
+++ b/src/sdl/sf_resource.c
@@ -383,8 +383,8 @@ void os_scrollback_erase (int erase)
  */
 void os_restart_game(int stage)
   {
-	// Show Beyond Zork's title screen
-  if ((stage == RESTART_BEGIN) && (story_id == BEYOND_ZORK))
+    // Show Beyond Zork's title screen
+    if ((stage == RESTART_END) && (story_id == BEYOND_ZORK))
 	{
 	int w,h;
 	if (os_picture_data(1,&h,&w))

--- a/src/sdl/sf_resource.c
+++ b/src/sdl/sf_resource.c
@@ -442,6 +442,7 @@ void sf_readsettings(void)
   m_fontfiles[5] = sf_GetProfileString("Fonts","fixedbold",NULL);
   m_fontfiles[6] = sf_GetProfileString("Fonts","fixeditalic",NULL);
   m_fontfiles[7] = sf_GetProfileString("Fonts","fixedbolditalic",NULL);
+  m_fontfiles[8] = sf_GetProfileString("Fonts","graphics",NULL);
 
   ResDir = sf_GetProfileString("Resources","Dir",ResDir);
   ResPict = sf_GetProfileString("Resources","Pict",ResPict);

--- a/src/sdl/sf_resource.c
+++ b/src/sdl/sf_resource.c
@@ -904,6 +904,7 @@ int sf_getresource( int num, int ispic, int method, myresource * res)
 
   if (ispic) usage = bb_ID_Pict;
   else usage = bb_ID_Snd;
+  //XXX Should use bb_load_resource_{pict,snd} with auxdata?
   st = bb_load_resource(bmap,method,(bb_result_t *)res,usage,num);
   if (st == bb_err_None)
 	{
@@ -1018,20 +1019,22 @@ static FILE * findfromlist( int ispic, int num, int *size)
 
 void os_init_setup(void)
 {
-	f_setup.attribute_assignment = 0;
-	f_setup.attribute_testing = 0;
-	f_setup.context_lines = 0;
-	f_setup.object_locating = 0;
-	f_setup.object_movement = 0;
-	f_setup.left_margin = 0;
-	f_setup.right_margin = 0;
-	f_setup.ignore_errors = 0;
-	f_setup.piracy = 0;             /* enable the piracy opcode */
-	f_setup.undo_slots = MAX_UNDO_SLOTS;
-	f_setup.expand_abbreviations = 0;
-	f_setup.script_cols = 80;
-	f_setup.sound = 1;
-	f_setup.err_report_mode = ERR_DEFAULT_REPORT_MODE;
-	f_setup.restore_mode = 0;
+    sf_setdialog();
+    sf_initloader();
 
+    f_setup.attribute_assignment = 0;
+    f_setup.attribute_testing = 0;
+    f_setup.context_lines = 0;
+    f_setup.object_locating = 0;
+    f_setup.object_movement = 0;
+    f_setup.left_margin = 0;
+    f_setup.right_margin = 0;
+    f_setup.ignore_errors = 0;
+    f_setup.piracy = 0;             /* enable the piracy opcode */
+    f_setup.undo_slots = MAX_UNDO_SLOTS;
+    f_setup.expand_abbreviations = 0;
+    f_setup.script_cols = 80;
+    f_setup.sound = 1;
+    f_setup.err_report_mode = ERR_DEFAULT_REPORT_MODE;
+    f_setup.restore_mode = 0;
 }

--- a/src/sdl/sf_sig.c
+++ b/src/sdl/sf_sig.c
@@ -76,7 +76,6 @@ static void bt_sighandler(int sig, siginfo_t *info,
                                    void *secret) {
 
   void *trace[16];
-  char **messages = (char **)NULL;
   char *nam;
   int i, trace_size = 0;
   ucontext_t *uc = (ucontext_t *)secret;
@@ -88,7 +87,7 @@ static void bt_sighandler(int sig, siginfo_t *info,
 
   printf("\nInterpreter bug!\nSignal %d ", sig);
   if ((nam = getsigname(sig))) printf("[%s] ",nam);
-  printf("from %p", uc->uc_mcontext.gregs[_PROG_COUNTER]);
+  printf("from %p", (void *)uc->uc_mcontext.gregs[_PROG_COUNTER]);
 
   if (sig == SIGSEGV)
         printf(" [faulty address is %p]",info->si_addr);

--- a/src/sdl/sf_sound.c
+++ b/src/sdl/sf_sound.c
@@ -335,8 +335,10 @@ void os_start_sample(int number, int volume, int repeats, zword eos)
 	// NOTE: geteffect may return an already loaded effect
   e = geteffect(number);
   if (!e) return;
-  if (e->type == SFX_TYPE) stopsample();
-  else stopmodule();
+  if (e->type == SFX_TYPE)
+      stopsample();
+  else
+      stopmodule();
   if (repeats < 1) repeats = 1;
   if (repeats == 255) repeats = -1;
   if (volume < 0) volume = 0;
@@ -389,7 +391,7 @@ void sf_checksound()
 	if (e_sfx->eos)
 		{
 		end_of_sound_flag = 1;
-		end_of_sound(e_sfx->eos);
+		end_of_sound();
 		}
 	}
   if ((e_mod) && (e_mod->ended))
@@ -398,7 +400,7 @@ void sf_checksound()
 	if (e_mod->eos)
 		{
 		end_of_sound_flag = 1;
-		end_of_sound(e_mod->eos);
+		end_of_sound();
 		}
 	}
   }

--- a/src/sdl/sf_sound.c
+++ b/src/sdl/sf_sound.c
@@ -231,9 +231,7 @@ static EFFECT *getmodule( FILE *f, size_t pos, int len, int num)
 	}
   else
 	{
-	FILE *f2 = fdopen(dup(fileno(f)),"rb");
-	fseek(f2,pos,SEEK_SET);
-	res->mod = Mix_LoadMUS_RW(SDL_RWFromFP(f2,1));
+	res->mod = Mix_LoadMUS_RW(SDL_RWFromFP(f, false));
 	}
   if (!res->mod)
 	{

--- a/src/sdl/sf_sound.c
+++ b/src/sdl/sf_sound.c
@@ -67,6 +67,13 @@ static void finishaudio()
 static void music_finished(void);
 static void channel_finished(int channel);
 
+/*
+ * This interface is broken.  The function gets called regardless of
+ * whether sound is desired and has no means for indicating whether sound is
+ * available.  See sf_initsound for the real init.
+ */
+void os_init_sound() {}
+
 int sf_initsound()
   {
   if (SFaudiorunning) return 1;

--- a/src/sdl/sf_sound.c
+++ b/src/sdl/sf_sound.c
@@ -46,7 +46,7 @@ static int audio_rate, audio_channels;
 		// the higher it is, the more FPS shown and CPU needed
 static int audio_buffers=512;
 static Uint16 audio_format;
-static int volume = SDL_MIX_MAXVOLUME;
+//static int volume = SDL_MIX_MAXVOLUME;
 static int bits;
 
 static void finishaudio()
@@ -243,7 +243,7 @@ static EFFECT *getmodule( FILE *f, size_t pos, int len, int num)
   return res;
   }
 
-static EFFECT *geteffect( num)
+static EFFECT *geteffect(int num)
   {
   myresource res;
   EFFECT *result = NULL;

--- a/src/sdl/sf_util.c
+++ b/src/sdl/sf_util.c
@@ -177,11 +177,6 @@ static void usage()
 
 static const char *progname = NULL;
 
-extern char script_name[];
-extern char command_name[];
-extern char save_name[];
-extern char auxilary_name[];
-
 char stripped_story_name[100];
 
 extern char *optarg;
@@ -334,14 +329,8 @@ static char *new_basename(const char *path)
 void os_process_arguments (int argc, char *argv[])
 {
   char *p;
-  int i;
-
-	// install signal handlers
 
   sf_installhandlers();
-
-    /* Parse command line options */
-
   parse_options(argc, argv);
 
   if (optind != argc - 1) 
@@ -349,13 +338,9 @@ void os_process_arguments (int argc, char *argv[])
 	usage();
 	exit (EXIT_FAILURE);
 	}
-
-    /* Set the story file name */
-
   f_setup.story_file = strdup(argv[optind]);
 
-	// load resources
-	// it's useless to test the retval, as in case of error it does not return
+  // it's useless to test the retval, as in case of error it does not return
   sf_load_resources( f_setup.story_file);
 
     /* Strip path and extension off the story file name */
@@ -553,7 +538,6 @@ int os_read_file_name (char *file_name, const char *default_name, int flag)
   {
   int st;
   const char *initname = default_name;
-  char *ext = ".aux";
 
   if (newfile(flag))
     {
@@ -790,12 +774,13 @@ static char * findsect( const char *sect)
     if (strncmp(r,sect,ns)) continue;
     return (r+ns);
     }
+  return NULL;
   }
 
 static char * findid( const char *sect, const char *id)
   {
   int nid = strlen(id);
-  char *p, *r, *sav, *rq, *fnd = NULL;
+  char *r, *sav, *rq, *fnd = NULL;
   r = findsect(sect);
 //printf("findsect(%s) %p\n",sect,r);
   if (!r) return NULL;
@@ -924,7 +909,7 @@ static int myunzip( int csize, byte *cdata, byte *udata)
 
 int sf_pkread( FILE *f, int foffs,  void ** out, int *size)
   {
-  byte hd[30], *dest;
+  byte hd[30];
   byte *data, *cdata;
   int csize, usize, cmet, skip, st;
 

--- a/src/sdl/sf_util.c
+++ b/src/sdl/sf_util.c
@@ -11,6 +11,7 @@
 
 #include "sf_frotz.h"
 
+f_setup_t f_setup;
 
 typedef void (*CLEANFUNC)();
 

--- a/src/sdl/sf_util.c
+++ b/src/sdl/sf_util.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <time.h>
 
+#include <libgen.h>
+
 #include <zlib.h>
 
 #ifdef __WIN32__
@@ -307,6 +309,28 @@ static void parse_options (int argc, char **argv)
  *
  */
 
+/**
+ * Like dirname except well defined.
+ * Does not modify path.  Always returns a new string (caller must free).
+ */
+static char *new_dirname(const char *path)
+{
+    char *p = strdup(path), *p2 = strdup(dirname(p));
+    free(p);
+    return p2;
+}
+
+/**
+ * Like basename except well defined.
+ * Does not modify path.  Always returns a new string (caller must free).
+ */
+static char *new_basename(const char *path)
+{
+    char *p = strdup(path), *p2 = strdup(basename(p));
+    free(p);
+    return p2;
+}
+
 void os_process_arguments (int argc, char *argv[])
 {
   char *p;
@@ -336,7 +360,7 @@ void os_process_arguments (int argc, char *argv[])
 
     /* Strip path and extension off the story file name */
 
-  f_setup.story_name = strdup(basename(argv[optind]));
+  f_setup.story_name = new_basename(argv[optind]);
 
   /* Now strip off the extension. */
   p = strrchr(f_setup.story_name, '.');
@@ -359,8 +383,7 @@ void os_process_arguments (int argc, char *argv[])
         *p = '\0';      /* extension removed */
       }
     }
-
-  f_setup.story_path = strdup(dirname(argv[optind]));
+  f_setup.story_path = new_dirname(argv[optind]);
 
   /* Create nice default file names */
 

--- a/src/sdl/sf_video.c
+++ b/src/sdl/sf_video.c
@@ -375,6 +375,14 @@ void os_scroll_area(int top, int left, int bottom, int right, int units)
 //		theWnd->FlushDisplay();
   }
 
+bool os_repaint_window(int win, int ypos_old, int ypos_new, int xpos,
+                       int ysize, int xsize)
+{
+    //TODO
+    return FALSE;
+}
+
+
 int SFdticks = 200;
 volatile bool SFticked = 0;
 static SDL_TimerID timerid = 0;

--- a/src/sdl/sf_video.c
+++ b/src/sdl/sf_video.c
@@ -850,7 +850,7 @@ zchar os_read_line(int max, zchar *buf, int timeout, int width, int continued)
 			{
 			if (pos == (int)mywcslen(buf))
 				{
-				zword extension[10], *s;
+				zchar extension[10], *s;
 				completion(buf,extension);
 
 					// Add the completion to the input stream

--- a/src/sdl/sf_video.c
+++ b/src/sdl/sf_video.c
@@ -7,6 +7,8 @@
 
 #include <SDL.h>
 
+#include "generic.h"
+
 #include "sf_frotz.h"
 
 static SDL_Rect blitrect = {0,0,0,0};
@@ -720,27 +722,6 @@ zchar os_read_key(int timeout, int cursor)
   return sf_read_key(timeout,cursor,0);
   }
 
-#define MAXHISTORY 8192
-static zword History[MAXHISTORY] = {0};
-static int histptr = 0;
-static void addtoHistory( zchar *buf)
-  {
-  int n = mywcslen(buf)+2;
-  int avail = MAXHISTORY - histptr;
-  if (n <= 2) return;
-  while (avail < n)
-    {
-    int k;
-    if (histptr == 0) return;
-    k = History[histptr-1]+2;
-    histptr -= k;
-    }
-  if (histptr) memmove(History+n,History,histptr*sizeof(zword));
-  histptr += n;
-  n -= 2;
-  History[0] = History[n+1] = n;
-  memcpy(History+1,buf,n*sizeof(zword));
-  }
 
 /*
  * os_read_line
@@ -788,182 +769,130 @@ static void addtoHistory( zchar *buf)
  *
  */
 zchar os_read_line(int max, zchar *buf, int timeout, int width, int continued)
-  {
-  static int prev_pos = 0;
-  static int prev_history = -1;
-  int pos = 0;
-  int history = -1;
-  int ptx,pty;
-  SF_textsetting * ts = sf_curtextsetting();
-  SDL_Event event;
+{
+    static int pos = 0, searchpos = -1;
+    int ptx,pty;
+    int len = mywcslen(buf);
+    SF_textsetting * ts = sf_curtextsetting();
+    SDL_Event event;
 
-//printf("os_read_line mx%d buf[0]%d tm%d w%d c%d\n",max,buf[0],timeout,width,continued);
-//	LineInput line;
-  sf_flushtext();
-//	theWnd->ResetOverhang();
-//	theWnd->UpdateMenus();
-//	theWnd->RecaseInput(buf);
+    //printf("os_read_line mx%d buf[0]%d tm%d w%d c%d\n",max,buf[0],timeout,width,continued);
+    //	LineInput line;
+    sf_flushtext();
+    //	theWnd->ResetOverhang();
+    //	theWnd->UpdateMenus();
+    //	theWnd->RecaseInput(buf);
 
-	// Find the editing position
-  if (continued)
-	{
-	if (prev_pos <= (int)mywcslen(buf))
-		pos = prev_pos;
-	}
-  else
-	pos = mywcslen(buf);
-
-//printf("pos %d\n",pos);
-	// Find the input history position
-  if (continued)
-	history = prev_history;
-
-	// Draw the input line
-  ptx = ts->cx;
-  pty = ts->cy;
-//	CPoint point = theWnd->GetTextPoint();
-  ptx -= os_string_width(buf);	//theWnd->GetTextWidth(buf,mywcslen(buf));
-  sf_DrawInput(buf,pos,ptx,pty,width,true);
-
-  if (timeout) mytimeout = sf_ticks() + m_timerinterval*timeout;
-//	InputTimer timer(timeout);
-  while (true)
-    {
-		// Get the next input
-    while (SDL_PollEvent(&event)) 
-	{
-	zword c;
-	if ((c = goodzkey(&event,1))) 
-		{
-//printf("goodzk %4x\n",c);
-		if (c == ZC_BACKSPACE)
-			{
-				// Delete the character to the left of the cursor
-			if (pos > 0)
-				{
-				memmove(buf+pos-1,buf+pos,sizeof(zword)*(mywcslen(buf)-pos+1));
-				pos--;
-				sf_DrawInput(buf,pos,ptx,pty,width,true);
-				}
-			}
-		else if (c == VK_TAB)
-			{
-			if (pos == (int)mywcslen(buf))
-				{
-				zchar extension[10], *s;
-				completion(buf,extension);
-
-					// Add the completion to the input stream
-				for (s = extension; *s != 0; s++)
-				  if (sf_IsValidChar(*s))
-					buf[pos++] = (*s);
-				buf[pos] = 0;
-				sf_DrawInput(buf,pos,ptx,pty,width,true);
-				}
-			}
-		else if ((c == ZC_ARROW_LEFT))
-			{
-				// Move the cursor left
-			if (pos > 0)
-				pos--;
-			sf_DrawInput(buf,pos,ptx,pty,width,true);
-			}
-		else if ((c == ZC_ARROW_RIGHT))
-			{
-				// Move the cursor right
-			if (pos < (int)mywcslen(buf))
-				pos++;
-			sf_DrawInput(buf,pos,ptx,pty,width,true);
-			}
-		else if ((c == ZC_ARROW_UP))
-			{
-			int n; zword *p;
-			// Move up through the command history
-			if (history >= 0)
-				{
-				n = History[history];
-				if (n) history += (n+2);
-				}
-			else
-				history = 0;
-			n = History[history];
-			p = History + history + 1;
-			pos = 0;
-			while (n) { buf[pos++] = *p++; n--;}
-			buf[pos] = 0;
-			sf_DrawInput(buf,pos,ptx,pty,width,true);
-			}
-		else if ((c == ZC_ARROW_DOWN))
-			{
-				// Move down through the command history
-			pos = 0;
-			if (history > 0)
-				{
-				int n; zword *p;
-				n = History[history-1];
-				history -= (n+2);
-				p = History + history + 1;
-				while (n) { buf[pos++] = *p++; n--; }
-				}
-			else
-				history = -1;
-			buf[pos] = 0;
-			sf_DrawInput(buf,pos,ptx,pty,width,true);
-			}
-		else if (is_terminator(c))
-			{
-				// Terminate the current input
-			m_exitPause = false;
-			sf_DrawInput(buf,pos,ptx,pty,width,false);
-
-			if ((c == ZC_SINGLE_CLICK) || (c == ZC_DOUBLE_CLICK))
-				{
-/*				mouse_x = input.mousex+1;
-				mouse_y = input.mousey+1;*/
-				}
-			else if (c == ZC_RETURN)
-				addtoHistory(buf);	//theWnd->AddToInputHistory(buf);
-
-//			theWnd->SetLastInput(buf);
-			prev_pos = pos;
-			prev_history = history;
-			return c;
-			}
-		else if (sf_IsValidChar(c))
-			{
-				// Add a valid character to the input line
-			if ((int)mywcslen(buf) < max)
-				{
-					// Get the width of the new input line
-				int len = os_string_width(buf);
-				len += os_char_width(c);
-				len += os_char_width('0');
-
-//printf("l%d w%d p%d\n",len,width,pos);
-					// Only allow if the width limit is not exceeded
-				if (len <= width)
-					{
-					memmove(buf+pos+1,buf+pos,sizeof(zword)*(mywcslen(buf)-pos+1));
-					*(buf+pos) = c;
-					pos++;
-					sf_DrawInput(buf,pos,ptx,pty,width,true);
-					}
-				}
-			}
-		}
-	}
-    if ((timeout) && (sf_ticks() >= mytimeout))
-	{
-	prev_pos = pos;
-	prev_history = history;
-	return ZC_TIME_OUT;
-	}
-    sf_checksound();
-    sf_sleep(10);
+    /* Better be careful here or it might segv.  I wonder if we should just
+       ignore 'continued' and check for len > 0 instead?  Might work better
+       with Beyond Zork. */
+    if (!continued || pos > len || searchpos > len) {
+        pos = len;
+        gen_history_reset();    /* Reset user's history view. */
+        searchpos = -1;         /* -1 means initialize from len. */
     }
 
-  return 0;
-  }
+    // Draw the input line
+    ptx = ts->cx;
+    pty = ts->cy;
+    //	CPoint point = theWnd->GetTextPoint();
+    ptx -= os_string_width(buf);	//theWnd->GetTextWidth(buf,mywcslen(buf));
+    sf_DrawInput(buf,pos,ptx,pty,width,true);
+
+    if (timeout) mytimeout = sf_ticks() + m_timerinterval*timeout;
+    //	InputTimer timer(timeout);
+    while (true) {
+        // Get the next input
+        while (SDL_PollEvent(&event)) {
+            zword c;
+            if ((c = goodzkey(&event,1))) {
+                //printf("goodzk %4x\n",c);
+                switch (c) {
+                case ZC_BACKSPACE:
+                    // Delete the character to the left of the cursor
+                    if (pos > 0) {
+                        memmove(buf+pos-1,buf+pos,sizeof(zword)*(mywcslen(buf)-pos+1));
+                        pos--;
+                        sf_DrawInput(buf,pos,ptx,pty,width,true);
+                    }
+                    break;
+                case VK_TAB:
+                    if (pos == (int)mywcslen(buf)) {
+                        zchar extension[10], *s;
+                        completion(buf,extension);
+
+                        // Add the completion to the input stream
+                        for (s = extension; *s != 0; s++)
+                            if (sf_IsValidChar(*s))
+                                buf[pos++] = (*s);
+                        buf[pos] = 0;
+                        sf_DrawInput(buf,pos,ptx,pty,width,true);
+                    }
+                    break;
+                case ZC_ARROW_LEFT:
+                    // Move the cursor left
+                    if (pos > 0)
+                        pos--;
+                    sf_DrawInput(buf,pos,ptx,pty,width,true);
+                    break;
+                case ZC_ARROW_RIGHT:
+                    // Move the cursor right
+                    if (pos < (int)mywcslen(buf))
+                        pos++;
+                    sf_DrawInput(buf,pos,ptx,pty,width,true);
+                    break;
+                case ZC_ARROW_UP:
+                case ZC_ARROW_DOWN:
+                    if (searchpos < 0)
+                        searchpos = mywcslen(buf);
+                    if ((c == ZC_ARROW_UP
+                         ? gen_history_back : gen_history_forward)(
+                                 buf, searchpos, max)) {
+                        pos = mywcslen(buf);
+                        sf_DrawInput(buf,pos,ptx,pty,width,true);
+                    }
+                    break;
+                default:
+                    if (is_terminator(c)) {
+                        // Terminate the current input
+                        m_exitPause = false;
+                        sf_DrawInput(buf,pos,ptx,pty,width,false);
+
+                        if ((c == ZC_SINGLE_CLICK) || (c == ZC_DOUBLE_CLICK)) {
+                            /*	mouse_x = input.mousex+1;
+				mouse_y = input.mousey+1;*/
+                        } else if (c == ZC_RETURN)
+                            gen_add_to_history(buf);
+                        //			theWnd->SetLastInput(buf);
+                        return c;
+                    } else if (sf_IsValidChar(c) && mywcslen(buf) < max) {
+                        // Add a valid character to the input line
+                        // Get the width of the new input line
+                        int len = os_string_width(buf);
+                        len += os_char_width(c);
+                        len += os_char_width('0');
+
+                        //printf("l%d w%d p%d\n",len,width,pos);
+                        // Only allow if the width limit is not exceeded
+                        if (len <= width) {
+                            memmove(buf+pos+1,buf+pos,sizeof(zword)*(mywcslen(buf)-pos+1));
+                            *(buf+pos) = c;
+                            pos++;
+                            sf_DrawInput(buf,pos,ptx,pty,width,true);
+                        }
+                    }
+                }
+            }
+        }
+        if ((timeout) && (sf_ticks() >= mytimeout)) {
+            return ZC_TIME_OUT;
+        }
+        sf_checksound();
+        sf_sleep(10);
+    }
+
+    return 0;
+}
 
 // Draw the current input line
 void sf_DrawInput(zchar * buffer, int pos, int ptx, int pty, int width, bool cursor)


### PR DESCRIPTION
SDL Frotz now builds and runs again. It gets built by default along with curses and dumb. Of course you then need SDL, SDL_mixer, libpng, libjpeg, freetype2, libz and pkgconfig. The code compiles without warnings with current CFLAGS. I removed -Wextra because I think it produces too many false positives for regular use (I also went from gnu99 to c99 plus some POSIX).

There used to be some documentation by Aldo Cumani. It has been removed but fortunately Git remembers. Not knowing the reason for removal I have not restored it, but some documentation would definitely be appropriate. Anyway, sfrotz reads .sfrotzrc from the current (not home) directory. The syntax is that of a Windows ini file. You can specify fonts, among other things. As a new item you can specify a scalable graphics font. You should either should do so (anyone up to drawing us a nice one?) or not change any monospace fonts. The graphics font must be scaled to fit monospace text and we don't have a general bitmap scaler (unlike Winfrotz). Feel free to play with the proportional fonts though. They should not have ridiculously disparate size from monospace (16 pixels for the built-in font) but don't have to be an exact match.

Much of the code is rather ugly and there is plenty of room for improvement, e.g., window resizing. But it is a somewhat portable interpreter with graphics and sound.
