### PR TITLE
src/common/quetzal.c: Do not implicitly fall through in case statement

### DIFF
--- a/src/common/quetzal.c
+++ b/src/common/quetzal.c
@@ -376,7 +376,9 @@ zword restore_quetzal (FILE *svf, FILE *stf)
 			progress |= GOT_MEMORY;	/* Only if succeeded. */
 		    break;
 	    }
-		/* Fall right thru (to default) if already GOT_MEMORY */
+		/* Already GOT_MEMORY */
+		(void) fseek (svf, currlen, SEEK_CUR);	/* Skip chunk. */
+		break;
 	    /* `UMem' uncompressed memory chunk; load it. */
 	    case ID_UMem:
 		if (!(progress & GOT_MEMORY))	/* Don't complain if two. */
@@ -391,10 +393,12 @@ zword restore_quetzal (FILE *svf, FILE *stf)
 			}
 		    }
 		    else
+		    	/* actually handle the problem outside if statement by skipping chunk. */
 			print_string ("`UMem' chunk wrong size!\n");
-		    /* Fall into default action (skip chunk) on errors. */
 		}
-		/* Fall thru (to default) if already GOT_MEMORY */
+		/* Already GOT_MEMORY */
+		(void) fseek (svf, currlen, SEEK_CUR);	/* Skip chunk. */
+		break;
 	    /* Unrecognised chunk type; skip it. */
 	    default:
 		(void) fseek (svf, currlen, SEEK_CUR);	/* Skip chunk. */


### PR DESCRIPTION
Sorry for the delay in getting back to you on [this](https://github.com/DavidGriffith/frotz/pull/63).

Rather than using the fallthrough attribute to mark the deliberate falls through as such, I've instead opted to skip the chunk in each spot (which is what would happen when it falls through). This way, compilers old and new can live in peace and harmony.

I should note that I wasn't sure how to actually test this functionality; I can say that saves definitely load successfully, but I don't have any with chunks to be skipped to test. Also, I don't have any old compilers lying around, so you might want to double-check my "peace and harmony" claim.

Share and enjoy!