### PR TITLE
src/curses/ux_init.c: End homebrewed strrchr function

### DIFF
--- a/src/curses/ux_init.c
+++ b/src/curses/ux_init.c
@@ -1091,6 +1091,7 @@ char *strrchr(const char *s, int c)
 	s++;
     }
     return (char *)save;
+}
 #endif	/* NO_STRRCHR */
 
 


### PR DESCRIPTION
At present, it is sort of ended by the #endif following it.